### PR TITLE
Improve dev setup experience

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,64 +4,108 @@ PUBLIC_URL="/dev/desktop"
 REACT_APP_MOUNT_PATH="/dev/desktop"
 
 # ==============================================================================
-# Configure paths to external services.
+# API service configuration
 #
-# The values selected here assume there is some external proxying taking place
-# to connect to the correct service.
+# The values selected here assume an external proxy.  If developing on
+# [OpenFlight Vagrant
+# Cluster](https://github.com/openflighthpc/openflight-vagrant-cluster) Flight
+# WWW will proxy the requests correctly.
 #
-# The `openflight-vagrant-cluster` is setup with such a proxy out of the box.
-# Alternatively, see `src/setupProxy` for how to configure `create-react-app`
-# to proxy.
-
+# If not developing on OpenFlight Vagrant Cluster, you may be best using the
+# alternate configuration below.
+#
+# NOTE:
+# * The `REACT_APP_*_BASE_URL`s can be toggled independently.
+# * `REACT_APP_API_BASE_URL` and `REACT_APP_CONFIG_FILE` must be from the same
+#   section.
+# * You need to restart this project's development server for these changes to
+#   take affect.
+#
 # Development services.
 # REACT_APP_LOGIN_API_BASE_URL="/dev/login/api/v0"
 # REACT_APP_API_BASE_URL="/dev/desktop/api/v2"
 # REACT_APP_CONFIG_FILE="/dev/desktop/config.dev.json"
 
-# Production services.
+# Production services.  That is those installed via the OS package manager.
 REACT_APP_LOGIN_API_BASE_URL="/login/api/v0"
 REACT_APP_API_BASE_URL="/desktop/api/v2"
 REACT_APP_CONFIG_FILE="/dev/desktop/config.prod-services.json"
 # ==============================================================================
 
 # ==============================================================================
-# ALTERNATE configure paths to external services.
+# ALTERNATE API service configuration using Flight Desktop Webapp to proxy
+# requests.
 #
-# If you are not using `openflight-vagrant-cluster` you can configure
-# `create-react-app` to proxy to the services for you.
+# Use this section if 1) you are not using OpenFlight Vagrant Cluster; or 2)
+# you are using OpenFlight Vagrant Cluster but wish to avoid using Flight WWW
+# to proxy requests.
 #
-# The following values assume that the services are running on
-# `flight.lvh.me`.  You may need to change hostnames and ports.
+# The server started by `yarn run start` can be used to proxy the requests.
+# The configuration given here does so.
 #
+# NOTE:
+# * The `REACT_APP_PROXY_*_PATH` must match the path in the corresponding
+#   `REACT_APP_*_BASE_URL`.
+# * The URLs are resolved from the machine running Flight Desktop Webapp.
+# * You may need to change hostnames and ports.
+#
+# REACT_APP_API_BASE_URL="/dev/desktop/api/v2"
+# REACT_APP_CONFIG_FILE="/dev/desktop/config.dev.json"
 # REACT_APP_PROXY_API="true"
 # REACT_APP_PROXY_API_PATH="/dev/desktop/api/v2"
 # REACT_APP_PROXY_API_URL="http://flight.lvh.me:6305"
 # REACT_APP_PROXY_API_PATH_REWRITE_FROM="^/dev/desktop/api"
 # REACT_APP_PROXY_API_PATH_REWRITE_TO="/"
 #
+# REACT_APP_LOGIN_API_BASE_URL="/dev/login/api/v0"
 # REACT_APP_PROXY_LOGIN_API="true"
-# REACT_APP_LOGIN_API_BASE_URL="http://flight.lvh.me:6311/v0"
 # REACT_APP_PROXY_LOGIN_API_PATH="/dev/login/api/v0"
 # REACT_APP_PROXY_LOGIN_API_URL="http://flight.lvh.me:6311"
-# REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_FROM="^/dev/login/api"
+# REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_FROM="^/dev/login/api/"
 # REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_TO="/"
 # ==============================================================================
 
 # ==============================================================================
-# Configure paths to environment, branding and styles.
+# ALTERNATE API service configuration without any proxying
+#
+# Use this section if 1) you are not using OpenFlight Vagrant Cluster; or 2)
+# you are using OpenFlight Vagrant Cluster but wish to avoid any proxied
+# requests.
+#
+# NOTE:
+# * The URLs given must be absolute.
+# * The services must be confgured to accept CORS.
+# * You will need to create an appropriate config.json for your needs.
+# * You may need to change the `PUBLIC_URL` and `REACT_APP_MOUNT_PATH` or you
+#   may not.
+# * Having the login server on a different host:port may not be well
+#   supported.
+# * This is largely untested, but can be made to work. Your mileage will vary.
+#   Use one of the options above.
+#
+# REACT_APP_API_BASE_URL="http://flight.lvh.me:16305/v2"
+# REACT_APP_LOGIN_API_BASE_URL="http://flight.lvh.me:16311/v0"
+# REACT_APP_CONFIG_FILE="/dev/desktop/config.custom.json"
+# PUBLIC_URL="/dev/desktop"
+# REACT_APP_MOUNT_PATH="/dev/desktop"
+# ==============================================================================
 
+
+# ==============================================================================
+# Configure paths to environment, branding and styles.
+#
 # These values, when used with `openflight-vagrant-cluster`, load the styles
 # from files inside this repo.
 REACT_APP_BRANDING_CSS_URL="/dev/desktop/styles/branding.css"
 REACT_APP_BRANDING_FILE="/dev/desktop/data/branding.dev.json"
 REACT_APP_ENVIRONMENT_FILE="/dev/desktop/data/environment.dev.json"
-
-# These values, when used with `openflight-vagrant-cluster`, load the styles
-# from the production landing page.
+#
+# These values, when used with OpenFlight Vagrant Cluster and proxying via
+# Flight WWW, load the styles from the production landing page.
 # REACT_APP_BRANDING_CSS_URL="/styles/branding.css"
 # REACT_APP_BRANDING_FILE="/data/branding.dev.json"
 # REACT_APP_ENVIRONMENT_FILE="/data/environment.dev.json"
-
+#
 # The values selected here load the styles from some external service.
 # REACT_APP_BRANDING_CSS_URL="http://localhost:3001/styles/branding.css"
 # REACT_APP_BRANDING_FILE="http://localhost:3001/data/branding.dev.json"

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,69 @@
+# See the `.env` file for comments.
+PORT=3001
+PUBLIC_URL="/dev/desktop"
+REACT_APP_MOUNT_PATH="/dev/desktop"
+
+# ==============================================================================
+# Configure paths to external services.
+#
+# The values selected here assume there is some external proxying taking place
+# to connect to the correct service.
+#
+# The `openflight-vagrant-cluster` is setup with such a proxy out of the box.
+# Alternatively, see `src/setupProxy` for how to configure `create-react-app`
+# to proxy.
+
+# Development services.
+# REACT_APP_LOGIN_API_BASE_URL="/dev/login/api/v0"
+# REACT_APP_API_BASE_URL="/dev/desktop/api/v2"
+# REACT_APP_CONFIG_FILE="/dev/desktop/config.dev.json"
+
+# Production services.
+REACT_APP_LOGIN_API_BASE_URL="/login/api/v0"
+REACT_APP_API_BASE_URL="/desktop/api/v2"
+REACT_APP_CONFIG_FILE="/dev/desktop/config.prod-services.json"
+# ==============================================================================
+
+# ==============================================================================
+# ALTERNATE configure paths to external services.
+#
+# If you are not using `openflight-vagrant-cluster` you can configure
+# `create-react-app` to proxy to the services for you.
+#
+# The following values assume that the services are running on
+# `flight.lvh.me`.  You may need to change hostnames and ports.
+#
+# REACT_APP_PROXY_API="true"
+# REACT_APP_PROXY_API_PATH="/dev/desktop/api/v2"
+# REACT_APP_PROXY_API_URL="http://flight.lvh.me:6305"
+# REACT_APP_PROXY_API_PATH_REWRITE_FROM="^/dev/desktop/api"
+# REACT_APP_PROXY_API_PATH_REWRITE_TO="/"
+#
+# REACT_APP_PROXY_LOGIN_API="true"
+# REACT_APP_LOGIN_API_BASE_URL="http://flight.lvh.me:6311/v0"
+# REACT_APP_PROXY_LOGIN_API_PATH="/dev/login/api/v0"
+# REACT_APP_PROXY_LOGIN_API_URL="http://flight.lvh.me:6311"
+# REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_FROM="^/dev/login/api"
+# REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_TO="/"
+# ==============================================================================
+
+# ==============================================================================
+# Configure paths to environment, branding and styles.
+
+# These values, when used with `openflight-vagrant-cluster`, load the styles
+# from files inside this repo.
+REACT_APP_BRANDING_CSS_URL="/dev/desktop/styles/branding.css"
+REACT_APP_BRANDING_FILE="/dev/desktop/data/branding.dev.json"
+REACT_APP_ENVIRONMENT_FILE="/dev/desktop/data/environment.dev.json"
+
+# These values, when used with `openflight-vagrant-cluster`, load the styles
+# from the production landing page.
+# REACT_APP_BRANDING_CSS_URL="/styles/branding.css"
+# REACT_APP_BRANDING_FILE="/data/branding.dev.json"
+# REACT_APP_ENVIRONMENT_FILE="/data/environment.dev.json"
+
+# The values selected here load the styles from some external service.
+# REACT_APP_BRANDING_CSS_URL="http://localhost:3001/styles/branding.css"
+# REACT_APP_BRANDING_FILE="http://localhost:3001/data/branding.dev.json"
+# REACT_APP_ENVIRONMENT_FILE="http://localhost:3001/data/environment.dev.json"
+# ==============================================================================

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,33 +4,75 @@ This documents explains howto setup and configure Flight Desktop Webapp for
 development.  For more details on contributing to the project see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Openflight Vagrant Cluster
+## Quick start
 
-Flight Desktop Webapp is designed to be developed on an [OpenFlight Vagrant
+The easiest way to get started developing Flight Desktop Webapp is to use
+[OpenFlight Vagrant
 Cluster](https://github.com/openflighthpc/openflight-vagrant-cluster).  The
 OpenFlight Vagrant Cluster repository contains details of how to install,
-configure and build an OpenFlightHPC cluster using Vagrant.  Follow the
-instructions there and then continue with the instructions here.
+configure and build an OpenFlightHPC cluster using Vagrant.
 
-## Configuring which services Flight Desktop Webapp uses
-
-By default, Flight Desktop Webapp is configured to use the production services
-installed on your OpenFlight Vagrant cluster.  You can configure the services
-it uses by editing the file [.env.development](.env.development) and
-restarting the service.  That file is well documented.
-
-## Starting Flight Desktop Webapp
-
-You can start the development version of Flight Desktop Webapp by running the
-following on `chead1` of your OpenFlight Vagrant cluster.
+Once OpenFlight Vagrant Cluster is running, you can develop Flight Destkop on
+your host machine and run it on OpenFlight Vagrant Cluster.  To start it:
 
 ```
 cd /code/flight-desktop-webapp
-/opt/flight/bin/yarn run start 
+yarn run start
 ```
 
-## Accessing the development build
+This will start Flight Desktop Webapp on port `3001` on `chead1`.  You can
+access it from your host at `https://flight.lvh.me:8443/dev/desktop`.  This
+proxies the request via Flight WWW.
 
-Once your OpenFlight Vagrant cluster is created, the development build of
-Flight Desktop Webapp will be available at
-https://flight.lvh.me:8443/dev/desktop.
+You can make changes to Flight Desktop Webapp on your host and those changes
+will be automatically picked up and compiled by Flight Desktop Webapp running
+on `chead1`.
+
+## Configuring which APIs to use
+
+TODO: complete this
+
+* The webapp can be configured to use either the development versions to the
+  APIs or to use the versions installed as part of `flight-web-suite`.
+* How to do so differs whether proxying via Flight WWW or accessing directly.
+
+When proxying via Flight WWW
+
+* Edit [.env.development](.env.development).
+* Comment and uncomment the appropriate `REACT_APP_*_BASE_URL` variables.
+* The `REACT_APP_CONFIG_FILE` variable must match the `REACT_APP_API_BASE_URL`
+  setting.  Either both development or both production.
+
+When accessing directly
+
+* Edit the `REACT_APP_PROXY_*` variables.
+* By default, they are set to use the development APIs.
+* The `REACT_APP_PROXY_*_URL`s are resolved from `chead1`.
+
+## Accessing without proxying via Flight WWW
+
+TODO: complete this
+
+* See [OpenFlight Vagrant
+  Cluster](https://github.com/openflighthpc/openflight-vagrant-cluster) for
+  details on how to expose the development ports.
+* Edit [.env.development](.env.development) and uncomment the
+  `REACT_APP_PROXY_*` settings.
+* Restart Flight Desktop Webapp `cd /code/flight-desktop-webapp; yarn run
+  start`.
+
+## Developing without using OpenFlight Vagrant Cluster
+
+TODO complete
+
+* Checkout the source code.
+* Install dependencies: `yarn`.
+* Checkout and start any dependent services. E.g., `flight-desktop-restapi`
+  and `flight-login-api`.
+* Edit [.env.development](.env.development); uncomment the `REACT_APP_PROXY_*`
+  settings; set to the appropriate values for your setup.
+* Start the development server: `yarn run start`.
+* Access it at http://localhost:3001
+
+Follow the
+instructions there and then continue with the instructions here.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,36 @@
+# Development setup
+
+This documents explains howto setup and configure Flight Desktop Webapp for
+development.  For more details on contributing to the project see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Openflight Vagrant Cluster
+
+Flight Desktop Webapp is designed to be developed on an [OpenFlight Vagrant
+Cluster](https://github.com/openflighthpc/openflight-vagrant-cluster).  The
+OpenFlight Vagrant Cluster repository contains details of how to install,
+configure and build an OpenFlightHPC cluster using Vagrant.  Follow the
+instructions there and then continue with the instructions here.
+
+## Configuring which services Flight Desktop Webapp uses
+
+By default, Flight Desktop Webapp is configured to use the production services
+installed on your OpenFlight Vagrant cluster.  You can configure the services
+it uses by editing the file [.env.development](.env.development) and
+restarting the service.  That file is well documented.
+
+## Starting Flight Desktop Webapp
+
+You can start the development version of Flight Desktop Webapp by running the
+following on `chead1` of your OpenFlight Vagrant cluster.
+
+```
+cd /code/flight-desktop-webapp
+/opt/flight/bin/yarn run start 
+```
+
+## Accessing the development build
+
+Once your OpenFlight Vagrant cluster is created, the development build of
+Flight Desktop Webapp will be available at
+https://flight.lvh.me:8443/dev/desktop.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ following the appropriate links.
 Fork the project. Make your feature addition or bug fix. Send a pull
 request. Bonus points for topic branches.
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) and [DEVELOPMENT.md](DEVELOPMENT.md)
+for more details.
 
 # Copyright and License
 

--- a/public/config.prod-services.json
+++ b/public/config.prod-services.json
@@ -1,5 +1,5 @@
 {
-  "apiRootUrl": "/dev/desktop/api/v2",
+  "apiRootUrl": "/desktop/api/v2",
   "websocketPathPrefix": "/ws",
   "websocketPathIp": "127.0.0.1"
 }

--- a/public/data/branding.dev.json
+++ b/public/data/branding.dev.json
@@ -1,16 +1,16 @@
 {
   "brandbar": {
     "logo": {
-      "url": "/desktop/images/bigv-uni-50x50.png",
+      "url": "/dev/desktop/images/bigv-uni-50x50.png",
       "alt": "BigV dev env logo",
       "classNames": "foo"
     },
-    "text": "University of BigV"
+    "text": ""
   },
   "apps": {
     "dashboard": {
       "logo": {
-        "url": "/desktop/images/bigv-uni.png",
+        "url": "/dev/desktop/images/bigv-uni.png",
         "alt": "BigV dev env logo",
         "classNames": "mb-4"
       }

--- a/public/data/environment.dev.json
+++ b/public/data/environment.dev.json
@@ -1,13 +1,13 @@
 {
   "environment": {
-    "name": "University of BigV dev env",
-    "description": "This is a dev environment for the University of BigV.",
+    "name": "Dev cluster",
+    "description": "This is a dev environment.",
     "logo": {
       "url": "",
       "classNames": ""
     }
   },
   "organisation": {
-    "name": "University of BigV"
+    "name": ""
   }
 }

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -31,7 +31,7 @@ module.exports = function(app) {
     app.use(
       process.env.REACT_APP_PROXY_LOGIN_API_PATH || '/login/api/v0',
       createProxyMiddleware({
-        target: process.env.REACT_APP_PROXY_LOGIN_API_PATH || 'http://localhost:6311',
+        target: process.env.REACT_APP_PROXY_LOGIN_API_URL || 'http://localhost:6311',
         changeOrigin: false,
         pathRewrite: {
           [rewriteFrom]: rewriteTo,

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,42 +1,56 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
-  // Proxy requests to the desktop api.
-  app.use(
-    '/desktop/api/v2',
-    createProxyMiddleware({
-      target: 'http://localhost:6305',
-      changeOrigin: false,
-      pathRewrite: {
-        '^/desktop/api/': '/', // Remove base path.
-      },
-      logLevel: 'debug',
-    })
-  );
+  if (process.env.REACT_APP_PROXY_API === "true") {
+    // Proxy requests to the desktop api.
+    const rewriteFrom = process.env.REACT_APP_PROXY_API_PATH_REWRITE_FROM ||
+      '^/dev/desktop/api';
+    const rewriteTo = process.env.REACT_APP_PROXY_API_PATH_REWRITE_TO ||
+      '/';
 
-  // Proxy requests to the login api.
-  app.use(
-    '/login/api/v0',
-    createProxyMiddleware({
-      target: 'http://localhost:6311',
-      changeOrigin: false,
-      pathRewrite: {
-        '^/login/api/': '/', // Remove base path.
-      },
-      logLevel: 'debug',
-    })
-  );
+    app.use(
+      process.env.REACT_APP_PROXY_API_PATH || '/desktop/api/v2',
+      createProxyMiddleware({
+        target: process.env.REACT_APP_PROXY_API_URL || 'http://localhost:6305',
+        changeOrigin: false,
+        pathRewrite: {
+          [rewriteFrom]: rewriteTo,
+        },
+        logLevel: 'debug',
+      })
+    );
+  }
+
+  if (process.env.REACT_APP_PROXY_LOGIN_API === "true") {
+    // Proxy requests to the login api.
+    const rewriteFrom = process.env.REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_FROM ||
+      '^/dev/login/api';
+    const rewriteTo = process.env.REACT_APP_PROXY_LOGIN_API_PATH_REWRITE_TO ||
+      '/';
+
+    app.use(
+      process.env.REACT_APP_PROXY_LOGIN_API_PATH || '/login/api/v0',
+      createProxyMiddleware({
+        target: process.env.REACT_APP_PROXY_LOGIN_API_PATH || 'http://localhost:6311',
+        changeOrigin: false,
+        pathRewrite: {
+          [rewriteFrom]: rewriteTo,
+        },
+        logLevel: 'debug',
+      })
+    );
+  }
 
   // Proxy requests to the landing page.
-  app.use(
-    [
-      '/data/',
-      '/styles/branding.css',
-    ],
-    createProxyMiddleware({
-      target: 'http://localhost:3001',
-      changeOrigin: false,
-      logLevel: 'debug',
-    })
-  );
+  // app.use(
+  //   [
+  //     '/data/',
+  //     '/styles/branding.css',
+  //   ],
+  //   createProxyMiddleware({
+  //     target: 'http://localhost:3001',
+  //     changeOrigin: false,
+  //     logLevel: 'debug',
+  //   })
+  // );
 };


### PR DESCRIPTION
Add a `.env.development` file which configures the app to work correctly on the `openflight-vagrant-cluster`.  By default it uses the production API services.