### PR TITLE
Fix copy in firefox and warn about pasting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+public/config.local.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/NoVNC.js
+++ b/src/NoVNC.js
@@ -121,7 +121,7 @@ export default class VncContainer extends React.Component {
           if (document.execCommand('copy')) {
             console.log("Copy succeeded!");
           } else {
-            console.log("Copy failed");
+            console.log("Copy failed!");
           }
         } catch(fallback_err) {
           console.log('err:', fallback_err);  // eslint-disable-line no-console

--- a/src/NoVNC.js
+++ b/src/NoVNC.js
@@ -76,6 +76,7 @@ export default class VncContainer extends React.Component {
   constructor(props) {
     super(props);
     this.noVNCCanvas = React.createRef();
+    this.copyFallback = React.createRef();
   }
 
   componentDidMount() {
@@ -105,18 +106,15 @@ export default class VncContainer extends React.Component {
         ]);
       } catch (err) {
         console.log('err:', err);  // eslint-disable-line no-console
-        let div = document.getElementById("copy-fallback-div")
-        let input = document.createElement("textarea");
         try {
           // Firefox does not support the ClipboardItem API at the time or writing.
           // It should *hopefully* support it in the future, so it is still attempted.
           // Until then, a fallback on a text area is used.
-          div.appendChild(input);
-          input.value = ev.detail.text;
-
+          //
           // The textarea must be visible in order to copy from it
-          input.style.display = "block";
-          input.select();
+          this.copyFallback.current.value = ev.detail.text;
+          this.copyFallback.current.style.display = 'block';
+          this.copyFallback.current.select();
 
           if (document.execCommand('copy')) {
             console.log("Copy succeeded!");
@@ -126,7 +124,8 @@ export default class VncContainer extends React.Component {
         } catch(fallback_err) {
           console.log('err:', fallback_err);  // eslint-disable-line no-console
         }
-        input.remove();
+        this.copyFallback.current.style.display = 'none';
+        this.copyFallback.current.value = '';
       }
     }
   }
@@ -182,10 +181,13 @@ export default class VncContainer extends React.Component {
 
   render() {
     return (
-      <div
-        ref={this.noVNCCanvas}
-        className={`${styles.NoVNCWrapper} fullscreen-content`}
-      />
+      <React.Fragment>
+        <div
+          ref={this.noVNCCanvas}
+          className={`${styles.NoVNCWrapper} fullscreen-content`}
+        />
+        <textarea ref={this.copyFallback} style={{display: "none"}}></textarea>
+      </React.Fragment>
     )
   }
 }

--- a/src/NoVNC.js
+++ b/src/NoVNC.js
@@ -105,8 +105,8 @@ export default class VncContainer extends React.Component {
         ]);
       } catch (err) {
         console.log('err:', err);  // eslint-disable-line no-console
-        var div = document.getElementById("copy-fallback-div")
-        var input = document.createElement("textarea");
+        let div = document.getElementById("copy-fallback-div")
+        let input = document.createElement("textarea");
         try {
           // Firefox does not support the ClipboardItem API at the time or writing.
           // It should *hopefully* support it in the future, so it is still attempted.

--- a/src/NoVNC.js
+++ b/src/NoVNC.js
@@ -186,7 +186,9 @@ export default class VncContainer extends React.Component {
           ref={this.noVNCCanvas}
           className={`${styles.NoVNCWrapper} fullscreen-content`}
         />
-        <textarea ref={this.copyFallback} style={{display: "none"}}></textarea>
+        <textarea ref={this.copyFallback} style={{
+          display: "none", height: "1px", maxHeight: "1px"
+        }}></textarea>
       </React.Fragment>
     )
   }

--- a/src/NoVNC.js
+++ b/src/NoVNC.js
@@ -105,6 +105,28 @@ export default class VncContainer extends React.Component {
         ]);
       } catch (err) {
         console.log('err:', err);  // eslint-disable-line no-console
+        var div = document.getElementById("copy-fallback-div")
+        var input = document.createElement("textarea");
+        try {
+          // Firefox does not support the ClipboardItem API at the time or writing.
+          // It should *hopefully* support it in the future, so it is still attempted.
+          // Until then, a fallback on a text area is used.
+          div.appendChild(input);
+          input.value = ev.detail.text;
+
+          // The textarea must be visible in order to copy from it
+          input.style.display = "block";
+          input.select();
+
+          if (document.execCommand('copy')) {
+            console.log("Copy succeeded!");
+          } else {
+            console.log("Copy failed");
+          }
+        } catch(fallback_err) {
+          console.log('err:', fallback_err);  // eslint-disable-line no-console
+        }
+        input.remove();
       }
     }
   }

--- a/src/PreparePasteButton.js
+++ b/src/PreparePasteButton.js
@@ -1,0 +1,81 @@
+import React, { useRef, useState } from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap'
+
+function PreparePasteButton({onPaste, onFallbackError, onFallbackPaste}) {
+  const [showFallback, setShowFallback] = useState(false);
+
+  const toggleFallback = function() {
+    setShowFallback(!showFallback);
+  }
+
+  return (
+    <React.Fragment>
+      <button
+        className="btn btn-sm btn-light"
+        onClick={async () => {
+          try {
+            const text = await navigator.clipboard.readText();
+            if (text !== "") {
+              onPaste(text)
+            }
+          } catch (e) {
+            console.log('Paste failed. Attempting fallback.', e);  // eslint-disable-line no-console
+            toggleFallback();
+          }
+        }}
+      >
+        <i className="fa fa-paste mr-1"></i>
+        Prepare paste
+      </button>
+      <FallbackPasteModal
+        isOpen={showFallback}
+        onError={onFallbackError}
+        onPaste={onFallbackPaste}
+        toggle={toggleFallback}
+      />
+    </React.Fragment>
+  );
+}
+
+function FallbackPasteModal({isOpen, onError, onPaste, toggle}) {
+  const textRef = useRef();
+
+  return (
+    <Modal isOpen={isOpen} toggle={toggle}>
+      <ModalHeader toggle={toggle}>Paste Text</ModalHeader>
+      <ModalBody>
+        <p>
+          To allow your desktop session to gain access to the pasted text,
+          paste your text in the text area below and click "OK".
+        </p>
+        <p>
+          Your session's clipboard will be updated and you will be able to
+          paste normally from within your session.
+        </p>
+        <textarea ref={textRef} style={{ width: "100%", height: "7em" }}></textarea>
+      </ModalBody>
+      <ModalFooter>
+        <button
+          className="btn btn-primary"
+          onClick={() => {
+            try {
+              onPaste(textRef.current.value);
+            } catch (e) {
+              console.log('Fallback failed.', e);  // eslint-disable-line no-console
+              onError(e);
+            } finally {
+              toggle();
+            }
+          }}
+        >
+          OK
+        </button>
+        <button className="btn btn-link" onClick={toggle}>
+          Cancel
+        </button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+export default PreparePasteButton;

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -128,8 +128,6 @@ function Connected({ id, session }) {
             ref={vnc}
           />
         </div>
-        <div id="copy-fallback-div">
-        </div>
       </ErrorBoundary>
     </Layout>
   );

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -278,10 +278,10 @@ function Toolbar({
         <textarea ref={fallbackText} style={{ width: "100%", height: "100%" }}></textarea>
       </ModalBody>
       <ModalFooter>
-        <button variant="secondary" onClick={toggleFallback}>
+        <button className="btn btn-secondary" onClick={toggleFallback}>
           Cancel
         </button>
-        <button variant="primary" onClick={ () => {
+        <button className="btn btn-primary" onClick={ () => {
           try {
             vnc.current.setClipboardText(fallbackText.current.value);
           } catch(e) {

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -246,8 +246,8 @@ function Toolbar({
       onClick={async () => {
         try {
           const text = await navigator.clipboard.readText();
-          if (text !== "" && this.vnc.current) {
-            this.vnc.current.setClipboardText(text);
+          if (text !== "" && vnc.current) {
+            vnc.current.setClipboardText(text);
           }
         } catch (e) {
           console.log('e:', e);  // eslint-disable-line no-console

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -279,7 +279,7 @@ function Toolbar({
     <Modal isOpen={showFallback}>
       <ModalHeader>Paste Text</ModalHeader>
       <ModalBody>
-        Please paste the text in the box below and press submit...
+        You must buffer the text before pasting within firefox.
         <textarea ref={fallbackText} style={{ width: "100%", height: "100%" }}></textarea>
       </ModalBody>
       <ModalFooter>
@@ -288,16 +288,13 @@ function Toolbar({
         </button>
         <button variant="primary" onClick={ () => {
           try {
-            console.log(vncRef.current);
-            // The following line does not work:
-            // TypeError: vncRef.current.currentSetClipboardText is not a function
-            vncRef.current.currentSetClipboardText(fallbackText.current.value);
+            vnc.current.setClipboardText(fallbackText.current.value);
           } catch(e) {
             console.log("e:", e);
           }
           handleCloseFallback();
         }}>
-          Submit
+          Buffer
         </button>
       </ModalFooter>
     </Modal>

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -204,13 +204,13 @@ function Toolbar({
   // the reference needs to be delayed
   if (vnc) { vncRef.current = vnc.current; }
 
-  const handleCloseFallback = function() {
+  const toggleFallback = function() {
     try {
       fallbackText.current.value = "";
     } catch(e) {
       console.log("Failed to clear textarea:", e);
     }
-    setShowFallback(false);
+    setShowFallback(!showFallback);
   }
 
   const disconnectBtn = connectionState === 'connected' ? (
@@ -258,7 +258,7 @@ function Toolbar({
           console.log('e:', e);  // eslint-disable-line no-console
           if (navigator.userAgent.indexOf("Firefox") !== -1) {
             console.log("Attempting firefox fallback");
-            setShowFallback(true);
+            toggleFallback();
 
           } else { // The paste will fail unless using HTTPs
             console.log("Paste failed!");
@@ -276,14 +276,14 @@ function Toolbar({
       <i className="fa fa-paste mr-1"></i>
       Prepare paste
     </button>
-    <Modal isOpen={showFallback}>
+    <Modal isOpen={showFallback} toggle={toggleFallback}>
       <ModalHeader>Paste Text</ModalHeader>
       <ModalBody>
         You must buffer the text before pasting within firefox.
         <textarea ref={fallbackText} style={{ width: "100%", height: "100%" }}></textarea>
       </ModalBody>
       <ModalFooter>
-        <button variant="secondary" onClick={handleCloseFallback}>
+        <button variant="secondary" onClick={toggleFallback}>
           Cancel
         </button>
         <button variant="primary" onClick={ () => {
@@ -292,7 +292,7 @@ function Toolbar({
           } catch(e) {
             console.log("e:", e);
           }
-          handleCloseFallback();
+          toggleFallback();
         }}>
           Buffer
         </button>

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -257,6 +257,13 @@ function Toolbar({
           const text = await navigator.clipboard.readText();
           if (text !== "" && vnc.current) {
             vnc.current.setClipboardText(text);
+            const body = (
+              <div>
+                Your session's clipboard has been updated. You can now paste
+                normally within your session.
+              </div>
+            );
+            addToast({body: body, icon: 'success', header: 'Paste prepared'});
           }
         } catch (e) {
           console.log('Paste failed. Attempting fallback.', e);  // eslint-disable-line no-console

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -197,12 +197,7 @@ function Toolbar({
 }) {
   const { addToast } = useToast();
   const fallbackText = useRef();
-  const vncRef = useRef();
   const [showFallback, setShowFallback] = useState(false);
-
-  // The vnc may not be defined on the initial rendering, so setting
-  // the reference needs to be delayed
-  if (vnc) { vncRef.current = vnc.current; }
 
   const toggleFallback = function() {
     try {

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -127,6 +127,8 @@ function Connected({ id, session }) {
             ref={vnc}
           />
         </div>
+        <div id="copy-fallback-div">
+        </div>
       </ErrorBoundary>
     </Layout>
   );

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -249,37 +249,39 @@ function Toolbar({
     }
   }
 
-  const pasteButton = <React.Fragment>
-    <button
-      className="btn btn-sm btn-light"
-      onClick={async () => {
-        try {
-          const text = await navigator.clipboard.readText();
-          if (text !== "" && vnc.current) {
-            vnc.current.setClipboardText(text);
-            const body = (
-              <div>
-                Your session's clipboard has been updated. You can now paste
-                normally within your session.
-              </div>
-            );
-            addToast({body: body, icon: 'success', header: 'Paste prepared'});
+  const pasteButton = connectionState === 'connected' ? (
+    <React.Fragment>
+      <button
+        className="btn btn-sm btn-light"
+        onClick={async () => {
+          try {
+            const text = await navigator.clipboard.readText();
+            if (text !== "" && vnc.current) {
+              vnc.current.setClipboardText(text);
+              const body = (
+                <div>
+                  Your session's clipboard has been updated. You can now paste
+                  normally within your session.
+                </div>
+              );
+              addToast({body: body, icon: 'success', header: 'Paste prepared'});
+            }
+          } catch (e) {
+            console.log('Paste failed. Attempting fallback.', e);  // eslint-disable-line no-console
+            toggleFallback();
           }
-        } catch (e) {
-          console.log('Paste failed. Attempting fallback.', e);  // eslint-disable-line no-console
-          toggleFallback();
-        }
-      }}
-    >
-      <i className="fa fa-paste mr-1"></i>
-      Prepare paste
-    </button>
-    <FallbackPasteModal
-      isOpen={showFallback}
-      toggle={toggleFallback}
-      onPaste={handleFallbackPaste}
-    />
-  </React.Fragment>
+        }}
+      >
+        <i className="fa fa-paste mr-1"></i>
+        Prepare paste
+      </button>
+      <FallbackPasteModal
+        isOpen={showFallback}
+        toggle={toggleFallback}
+        onPaste={handleFallbackPaste}
+      />
+    </React.Fragment>
+  ) : null;
 
   return (
     <div className="btn-toolbar" style={{ minHeight: '31px' }}>

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -1,5 +1,6 @@
 import React, { useContext, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { useToast } from './ToastContext';
 
 import {
   ConfigContext,
@@ -195,6 +196,8 @@ function Toolbar({
   session,
   vnc,
 }) {
+  const { addToast } = useToast();
+
   const disconnectBtn = connectionState === 'connected' ? (
     <button
       className="btn btn-secondary btn-sm mr-1"
@@ -238,6 +241,23 @@ function Toolbar({
           }
         } catch (e) {
           console.log('e:', e);  // eslint-disable-line no-console
+          var body;
+          if (navigator.userAgent.indexOf("Firefox") !== -1) {
+            body = (
+              <div>
+                Pasting content to VNC sessions is unsupported in Firefox!
+                Please trying again using a different browser.
+              </div>
+            );
+          } else { // The paste will fail unless using HTTPs
+            body = (
+              <div>
+                Paste is currently disabled! Please contact your system
+                administrator for further assistance.
+              </div>
+            );
+          }
+          addToast({body, icon: 'danger', header: 'Paste Disabled' });
         }
       }}
     >


### PR DESCRIPTION
`firefox` does not implement the `clipboard` API like the rest of the modern browsers. This means the `copy` and `paste` features do not work.

Fixing the `copy` feature is "reasonable" straight forward by adding the following fallback:
* Create a temporary `textarea` and dump the payload into it,
* Copy from the `textarea` using `execCommand("copy")`, and 
* Remove the `textarea`.

There are a couple of idiosyncrasies involved, particularly the `textarea` needs to be in a `block` style. As the `textarea` only exists briefly, it does not appear to be rendered by the browser. This implementation should be sufficient to move forward to acceptance testing.

---

Pasting is a different story... tl;dr It doesn't work

Browsers put various permission safe guards around reading from the clipboard as it commonly contains sensitive information (e.g. passwords). In `chrome` this takes the form of a dialog box prompting the user to provide the required permissions. `firefox` does not do this....

Instead `firefox` only allows access to the `clipboard` API in browser extensions. I attempted to use the `execCommand("paste")` action, however this gets disabled as well. AFAICS, it is not possible to programmatically  paste within `firefox`.

Instead a `toast` error is emitted telling the user that paste has been disabled and they will need to use a different browser.