### PR TITLE
Allow the webapp to connect to remote sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,6 @@ the cluster that is being managed.
 **websocketPathPrefix**: Set this to the path prefix that is proxied to
 websocket connections.
 
-**websocketPathIp**: The IP that the websocket proxy uses to connect to the
-websockify process.  If unset, the IP address reported by the session will be
-used.
-
-If the websocket proxy and the websockify process are running on the same
-machine, you probably want to set this to "127.0.0.1".  If they are not,
-you probably want to not have this set.
-
 Additionally, when installing from source, you may also
 configure the path at which the built application is to be mounted.
 

--- a/public/config.dev.json
+++ b/public/config.dev.json
@@ -1,5 +1,4 @@
 {
   "apiRootUrl": "/dev/desktop/api/v2",
-  "websocketPathPrefix": "/ws",
-  "websocketPathIp": "127.0.0.1"
+  "websocketPathPrefix": "/ws"
 }

--- a/public/config.json.example
+++ b/public/config.json.example
@@ -11,17 +11,7 @@
   "apiRootUrl": "https://gateway1.my.custer/desktop/api/v2",
 
   # The path prefix used for websocket connections.
-  "websocketPathPrefix": "/ws",
-
-  # The IP that the websocket proxy uses to connect to the websockify process.
-  #
-  # If unset, the IP address reported by the session will be used.
-  #
-  # If the websocket proxy and the websockify process are running on the same
-  # machine, you probably want to set this to "127.0.0.1".  If they are not,
-  # you probably want to not have this set.
-  "websocketPathIp": "127.0.0.1"
-
+  "websocketPathPrefix": "/ws"
 
 
 

--- a/public/config.prod-services.json
+++ b/public/config.prod-services.json
@@ -1,5 +1,4 @@
 {
   "apiRootUrl": "/desktop/api/v2",
-  "websocketPathPrefix": "/ws",
-  "websocketPathIp": "127.0.0.1"
+  "websocketPathPrefix": "/ws"
 }

--- a/public/config.test.json
+++ b/public/config.test.json
@@ -1,5 +1,4 @@
 {
   "apiRootUrl": "https://my.cluster.com/desktop",
-  "websocketPathPrefix": "/ws",
-  "websocketPathIp": "127.0.0.1"
+  "websocketPathPrefix": "/ws"
 }

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -30,7 +30,7 @@ function SessionCard({ reload, session }) {
           {sessionName}
         </h5>
         <div className={
-          classNames("card-body", { 'text-muted': activeStates.includes(session.state) })
+          classNames("card-body", { 'text-muted': !activeStates.includes(session.state) })
         }>
           <div className="row mb-2">
             <div className="col">

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -10,6 +10,7 @@ import { CardFooter } from './CardParts';
 import { prettyDesktopName } from './utils';
 
 const timeFormat = d3.timeFormat("%a %e %b %Y %H:%M");
+const activeStates = ['Active', 'Remote'];
 
 function timestampFormat(timestamp) {
   return timeFormat(new Date(timestamp));
@@ -29,7 +30,7 @@ function SessionCard({ reload, session }) {
           {sessionName}
         </h5>
         <div className={
-          classNames("card-body", { 'text-muted': session.state !== 'Active' })
+          classNames("card-body", { 'text-muted': activeStates.includes(session.state) })
         }>
           <div className="row mb-2">
             <div className="col">
@@ -50,7 +51,7 @@ function SessionCard({ reload, session }) {
               name="State"
               value={session.state}
               valueTitle={
-                session.state === 'Active' ?
+                activeStates.includes(session.state) ?
                   'This session is active.  You can connect to it to gain access.' :
                   'This session is no longer available.  To remove it from ' +
                   'this list, click the "Clean" button below.'
@@ -103,7 +104,7 @@ function MetadataEntry({ name, value, format, valueTitle }) {
 }
 
 function Buttons({ onCleaned, onTerminated, session }) {
-  if (session.state === 'Active') {
+  if (activeStates.includes(session.state)) {
     return (
       <div className="btn-toolbar justify-content-center">
         <Link
@@ -135,7 +136,7 @@ function Buttons({ onCleaned, onTerminated, session }) {
 
 function Screenshot({ session }) {
   const screenshot = <WrappedScreenshot className="card-img" session={session} />;
-  if (session.state === 'Active') {
+  if (activeStates.includes(session.state)) {
     return <Link to={`/sessions/${session.id}`}>{screenshot}</Link>;
   } else {
     return screenshot;

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -49,13 +49,21 @@ function SessionCard({ reload, session }) {
             />
             <MetadataEntry
               name="State"
-              value={session.state}
+              value={
+                activeStates.includes(session.state) ? 'Active' : session.state
+              }
               valueTitle={
                 activeStates.includes(session.state) ?
                   'This session is active.  You can connect to it to gain access.' :
                   'This session is no longer available.  To remove it from ' +
                   'this list, click the "Clean" button below.'
               }
+            />
+            <MetadataEntry
+              name="Host"
+              value={session.hostname}
+              valueTitle="The machine this session is running on"
+              format={host => <code>{host}</code>}
             />
             <MetadataEntry
               name="Started"

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -25,8 +25,7 @@ function buildWebsocketUrl(session, config) {
     // expected that the developer sets things up correctly.
     const rootUrl = config.devOnlyWebsocketRootUrl;
     const prefix = config.websocketPathPrefix;
-    const pathIP = config.websocketPathIp || session.ip;
-    return `${rootUrl}${prefix}/${pathIP}/${session.port}`;
+    return `${rootUrl}${prefix}/${session.ip}/${session.port}`;
 
   } else {
     const apiUrl = new URL(config.apiRootUrl, window.location.origin);
@@ -39,8 +38,7 @@ function buildWebsocketUrl(session, config) {
     }
 
     let prefix = config.websocketPathPrefix;
-    const pathIP = config.websocketPathIp || session.ip;
-    wsUrl.pathname = `${prefix}/${pathIP}/${session.port}`;
+    wsUrl.pathname = `${prefix}/${session.ip}/${session.port}`;
 
     return wsUrl.toString()
   }

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -161,6 +161,9 @@ function Layout({
   // `id` could be null when we are navigating away from the page.
   const { id } = useParams();
   const sessionName = id == null ? '' : id.split('-')[0];
+  const hostname = session == null ?
+    null :
+    <span>running on <code className="text-reset">{session.hostname}</code></span>;
 
   return (
     <div className="overflow-auto">
@@ -170,9 +173,9 @@ function Layout({
             <div className="card-header bg-primary text-light">
               <div className="row no-gutters">
                 <div className="col">
-                  <div className="d-flex align-items-center">
+                  <div className="d-flex flex-wrap align-items-center">
                     <h5 className="flex-grow-1 mb-0">
-                      {sessionName}
+                      {sessionName} {hostname}
                     </h5>
                     <Toolbar
                       connectionState={connectionState}

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -19,13 +19,25 @@ import styles from './NoVNC.module.css';
 import { useFetchSession } from './api';
 
 function buildWebsocketUrl(session, config) {
+  // Use 127.0.0.1 when connecting to a session on the host machine
+  // Otherwise use the provided IP when connecting to a remote session
+  //
+  // This gets around issues with AWS firewalls when trying to connect
+  // to a public IP
+  var ip;
+  if (session.state === 'Remote') {
+    ip = session.ip
+  } else {
+    ip = "127.0.0.1"
+  }
+
   if (config.devOnlyWebsocketRootUrl) {
     // This branch is intended for development and testing only.  The code
     // here is intentionally less robust in the URL it constructs.  It is
     // expected that the developer sets things up correctly.
     const rootUrl = config.devOnlyWebsocketRootUrl;
     const prefix = config.websocketPathPrefix;
-    return `${rootUrl}${prefix}/${session.ip}/${session.port}`;
+    return `${rootUrl}${prefix}/${ip}/${session.port}`;
 
   } else {
     const apiUrl = new URL(config.apiRootUrl, window.location.origin);
@@ -38,7 +50,7 @@ function buildWebsocketUrl(session, config) {
     }
 
     let prefix = config.websocketPathPrefix;
-    wsUrl.pathname = `${prefix}/${session.ip}/${session.port}`;
+    wsUrl.pathname = `${prefix}/${ip}/${session.port}`;
 
     return wsUrl.toString()
   }


### PR DESCRIPTION
This does two things:

* No longer considers `Remote` sessions as "broken", instead they are pseudo-active
* Uses the provided session IP to connect to the remote sessions.