### PR TITLE
Allow users to update their configs and quick launch sessions

### DIFF
--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -13,7 +13,7 @@ import {
 } from 'flight-webapp-components';
 
 import styles from './SessionsPage.module.css';
-import { useFetchUserConfig, useFetchDesktops } from './api';
+import { useFetchUserConfig, useFetchDesktops, useUpdateUserConfig } from './api';
 import { useInterval } from './utils';
 
 function ConfigsPage() {
@@ -47,10 +47,16 @@ function Layout({ configs, desktops }) {
   const [yGeometry, setYGeometry] = useState(y);
   const [modified, setModified] = useState(false);
 
-  // Create the updated
+  // Create the updater and onSubmitted
   const updater = function(setter, field) {
     if (! modified) { setModified(true) }
     setter(field.target.value);
+  }
+  const onSubmitted = function(data) {
+    setXGeometry(data.xGeometry);
+    setYGeometry(data.yGeometry);
+    setDesktop(data.desktop);
+    setModified(false);
   }
 
   if (configs == null) {
@@ -98,14 +104,36 @@ function Layout({ configs, desktops }) {
             </Col>
           </FormGroup>
           <FormGroup check>
-            <Button color="success" className="pull-right" disabled={!modified}>
-              Update Configuration
-            </Button>
+            <UpdateButton
+              desktop={desktop}
+              geometry={`${xGeometry}x${yGeometry}`}
+              modified={modified}
+              onSubmitted={onSubmitted}
+            />
           </FormGroup>
         </Form>
       </div>
     </div>
   );
+}
+
+function UpdateButton({desktop, geometry, modified, onSubmitted}) {
+  const { patch, response, error } = useUpdateUserConfig(desktop, geometry);
+  console.log("Rendering button");
+  console.log(desktop);
+  const submit = async() => {
+    // Create the submitter
+    const data = await patch();
+    if (response.ok) {
+      onSubmitted(data);
+    } else {
+      console.log("Failed to update");
+    }
+  }
+
+  return <Button color="success" className="pull-right" disabled={!modified} onClick={submit}>
+    Update Configuration
+  </Button>
 }
 
 function Loading() {

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -93,13 +93,18 @@ function Layout({ configs, desktops }) {
 
 function DesktopOptions({desktops, selected, original}) {
   return desktops.map(desktop => {
-    var element = null;
-    const pretty  = prettyDesktopName[desktop.id];
-    const label = original === desktop.id ? `${pretty} (default)` : pretty
-    if (desktop.verified) {
-      element = <option key={desktop.id} value={desktop.id} label={label} selected={selected}/>
+    var label = prettyDesktopName[desktop.id];
+    if (original === desktop.id) {
+      label = `${label} (default)`
     }
-    return element;
+    if (!desktop.verified) {
+      label = `${label} - (Disabled: Unverified)`
+    }
+    return <option  key={desktop.id}
+                    value={desktop.id}
+                    label={label}
+                    selected={selected}
+                    disabled={!desktop.verified}/>
   });
 }
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -117,11 +117,11 @@ function GeometryOptions({geometries, selected, original}) {
 
 function UpdateButton({desktop, geometry, originalStruct, setOriginalStruct}) {
   const { addToast } = useToast();
-  const { request, patch, response } = useUpdateUserConfig();
+  const { request, patch } = useUpdateUserConfig();
   const submit = async() => {
     // Create the submitter
     const data = await patch(desktop, geometry);
-    if (response.ok) {
+    if (request.response.ok) {
       if ( desktop === data.desktop && geometry === data.geometry) {
         // Update successful
         setOriginalStruct({

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -13,24 +13,25 @@ import {
 } from 'flight-webapp-components';
 
 import styles from './SessionsPage.module.css';
-import { useFetchUserConfig } from './api';
+import { useFetchUserConfig, useFetchDesktops } from './api';
 import { useInterval } from './utils';
 
 function ConfigsPage() {
-  const { data, error, loading, get } = useFetchUserConfig();
-  useInterval(get, 1 * 60 * 1000);
+  const config_req = useFetchUserConfig();
+  const desktop_req = useFetchDesktops();
 
-  if (error) {
-    if (utils.errorCode(data) === 'Unauthorized') {
+  if (config_req.error || desktop_req.error) {
+    req = (config_req.error ? config_req : desktop_req)
+    if (utils.errorCode(req.data) === 'Unauthorized') {
       return <UnauthorizedError />;
     } else {
       return <DefaultErrorMessage />;
     }
   } else {
-    if (loading) {
+    if (config_req.loading || desktop_req.loading) {
       return <Loading />;
     } else {
-      return <Layout configs={data} loading={loading} />
+      return <Layout configs={config_req.data} />
     }
   }
 }

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -45,6 +45,13 @@ function Layout({ configs, desktops }) {
   const [desktop, setDesktop] = useState(d);
   const [xGeometry, setXGeometry] = useState(x);
   const [yGeometry, setYGeometry] = useState(y);
+  const [modified, setModified] = useState(false);
+
+  // Create the updated
+  const updater = function(setter, field) {
+    if (! modified) { setModified(true) }
+    setter(field.target.value);
+  }
 
   if (configs == null) {
     console.log("The 'configs' where null")
@@ -52,9 +59,7 @@ function Layout({ configs, desktops }) {
   }
 
   return (
-    <div
-      className="card"
-    >
+    <div className="card" >
       <h4
         className="card-header text-truncate justify-content-between d-flex align-items-end"
         title={"User Configuration"}
@@ -63,13 +68,13 @@ function Layout({ configs, desktops }) {
           User Configuration
         </span>
       </h4>
-      <div className="card-body">
+      <div className="card-body container">
         <Form>
           <FormGroup row>
             <Label for="desktop" sm={2} size="lg">Desktop</Label>
             <Col>
               <Input  type="select" name="desktop" id="desktop" required
-                      value={desktop} onChange={e => setDesktop(e.target.value)}>
+                      value={desktop} onChange={e => updater(setDesktop, e)}>
                 {desktops.map(desktop => {
                   if (desktop.verified) {
                     return (<option>{desktop.id}</option>);
@@ -82,15 +87,20 @@ function Layout({ configs, desktops }) {
             <Label sm={2} size="lg">Geometry</Label>
             <Col>
               <Input  type="number" name="geometry-x" id="geometry-x" required
-                      placeholder="X Geometry" value={xGeometry} onChange={e => setXGeometry(e.target.value)}
+                      placeholder="X Geometry" value={xGeometry} onChange={e => updater(setXGeometry, e)}
               />
             </Col>
             <span sm="auto" size="lg" className="align-middle">X</span>
             <Col>
               <Input  type="number" name="geometry-y" id="geometry-y" required
-                      placeholder="Y Geometry" value={yGeometry} onChange={e => setYGeometry(e.target.value)}
+                      placeholder="Y Geometry" value={yGeometry} onChange={e => updater(setYGeometry, e)}
               />
             </Col>
+          </FormGroup>
+          <FormGroup check>
+            <Button color="success" className="pull-right" disabled={!modified}>
+              Update Configuration
+            </Button>
           </FormGroup>
         </Form>
       </div>

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -36,7 +36,7 @@ function ConfigsPage() {
 function Layout({ configs, desktops }) {
   // Determine the current settings
   const [x, y] = configs.geometry.split("x");
-  const d = desktops.map(d => d.id).includes(configs.desktop) ? configs.desktop : null;
+  const d = desktops.map(d => d.id).includes(configs.desktop) ? configs.desktop : desktops[0].id;
 
   // Create the state references
   const [desktop, setDesktop] = useState(d);
@@ -72,8 +72,7 @@ function Layout({ configs, desktops }) {
             <Col>
               <Input  type="select" name="desktop" id="desktop" required
                       value={desktop} onChange={e => updater(setDesktop, e)}>
-                <DisabledDesktopOption desktops={desktops} desktop={configs.desktop}/>
-                <DesktopOptions desktops={desktops}/>
+                <DesktopOptions desktops={desktops} default={desktop} />
               </Input>
             </Col>
           </FormGroup>
@@ -105,21 +104,11 @@ function Layout({ configs, desktops }) {
   );
 }
 
-function DisabledDesktopOption({desktops, desktop}) {
-  // Checks if the desktop exists and is verified
-  if (desktops.includes(d => { return d.id === desktop && d.verified })) {
-    return;
-  }
-
-  // Returns the disabled element
-  return(<option key={desktop} disabled>{desktop}</option>);
-}
-
-function DesktopOptions({desktops}) {
+function DesktopOptions({desktops, selected}) {
   return desktops.map(desktop => {
     var element = null;
     if (desktop.verified) {
-      element = <option key={desktop.id}>{desktop.id}</option>
+      element = <option key={desktop.id} selected={selected === desktop.id}>{desktop.id}</option>
     }
     return element;
   });
@@ -154,7 +143,7 @@ function UpdateButton({desktop, geometry, modified, setModified}) {
 function updateSuccessfulToast() {
   let body = (
     <div>
-      Your configuration has been updatede.
+      Your configuration has been updated.
     </div>
   );
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import {
+  Overlay,
+  OverlayContainer,
+  Spinner,
+  UnauthorizedError,
+  DefaultErrorMessage,
+  utils,
+} from 'flight-webapp-components';
+
+import { useFetchUserConfig } from './api';
+import { useInterval } from './utils';
+
+function ConfigsPage() {
+  const { data, error, loading, get } = useFetchUserConfig();
+  useInterval(get, 1 * 60 * 1000);
+
+  if (error) {
+    if (utils.errorCode(data) === 'Unauthorized') {
+      return <UnauthorizedError />;
+    } else {
+      return <DefaultErrorMessage />;
+    }
+  } else {
+    if (loading) {
+      return <Loading />;
+    } else {
+      return <Layout configs={data} loading={loading} />
+    }
+  }
+}
+
+function Layout({ configs }) {
+  if (configs == null) {
+    console.log("The 'configs' where null")
+    return <DefaultErrorMessage />;
+  }
+
+  return (
+    <div
+      className="card"
+    >
+      <h4
+        className="card-header text-truncate justify-content-between d-flex align-items-end"
+        title={"User Configuration"}
+      >
+        <span>
+          User Configuration
+        </span>
+      </h4>
+      <div className="card-body">
+        <dl>
+          <dt
+            className="text-truncate"
+            title="Desktop"
+          >
+            Desktop
+          </dt>
+          <dd
+            className="text-truncate"
+            title={configs.desktop}
+          >
+            {configs.desktop}
+          </dd>
+        </dl>
+      </div>
+    </div>
+  );
+}
+
+function Loading() {
+  return (
+    <Overlay>
+      <Spinner text="Loading config..." />
+    </Overlay>
+  );
+}
+
+export default ConfigsPage;

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -37,13 +37,11 @@ function ConfigsPage() {
 
 function Layout({ configs, desktops }) {
   // Determine the current settings
-  const [x, y] = configs.geometry.split("x");
   const d = desktops.map(d => d.id).includes(configs.desktop) ? configs.desktop : desktops[0].id;
 
   // Create the state references
   const [desktop, setDesktop] = useState(d);
-  const [xGeometry, setXGeometry] = useState(x);
-  const [yGeometry, setYGeometry] = useState(y);
+  const [geometry, setGeometry] = useState(configs.geometry);
   const [modified, setModified] = useState(false);
 
   // Create the updater
@@ -73,23 +71,20 @@ function Layout({ configs, desktops }) {
             <Label for="desktop">Desktop</Label>
             <Input  type="select" name="desktop" id="desktop" required
                     value={desktop} onChange={e => updater(setDesktop, e)}>
-              <DesktopOptions desktops={desktops} default={desktop} />
+              <DesktopOptions desktops={desktops} selected={desktop} />
             </Input>
           </FormGroup>
           <FormGroup>
             <Label>Geometry</Label>
-            <Input  type="number" name="geometry-x" id="geometry-x" required
-                    placeholder="X Geometry" value={xGeometry} onChange={e => updater(setXGeometry, e)}
-            />
-            <span sm="auto" size="lg" className="align-middle">X</span>
-            <Input  type="number" name="geometry-y" id="geometry-y" required
-                    placeholder="Y Geometry" value={yGeometry} onChange={e => updater(setYGeometry, e)}
-            />
+            <Input  type="select" name="geometry" id="geometry" required
+                    value={geometry} onChange={e => updater(setGeometry, e)}>
+              <GeometryOptions geometries={configs.geometries} selected={geometry} />
+            </Input>
           </FormGroup>
           <FormGroup check>
             <UpdateButton
               desktop={desktop}
-              geometry={`${xGeometry}x${yGeometry}`}
+              geometry={geometry}
               modified={modified}
               setModified={setModified}
             />
@@ -107,6 +102,12 @@ function DesktopOptions({desktops, selected}) {
       element = <option value={desktop.id} label={prettyDesktopName[desktop.id]} selected={selected === desktop.id}/>
     }
     return element;
+  });
+}
+
+function GeometryOptions({geometries, selected}) {
+  return geometries.map(geometry => {
+    return <option value={geometry} label={geometry} selected={selected === geometry}/>
   });
 }
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -112,11 +112,11 @@ function GeometryOptions({geometries, selected, original}) {
 
 function UpdateButton({desktop, geometry, originalStruct, setOriginalStruct}) {
   const { addToast } = useToast();
-  const { request, patch } = useUpdateUserConfig();
+  const { request, patch, response } = useUpdateUserConfig();
   const submit = async() => {
     // Create the submitter
     const data = await patch(desktop, geometry);
-    if (request.response.ok) {
+    if (response.ok) {
       if ( desktop === data.desktop && geometry === data.geometry) {
         // Update successful
         setOriginalStruct({
@@ -129,15 +129,15 @@ function UpdateButton({desktop, geometry, originalStruct, setOriginalStruct}) {
         addToast(updateFailedToast({ errorCode: "did-not-update" }));
       }
     } else {
-      console.log("Failed to update configuration");
+      console.log("Failed to update your configuration");
       addToast(updateFailedToast({ errorCode: utils.errorCode(data) }));
     }
   }
-  const is_original = (desktop === originalStruct.desktop) && (geometry === originalStruct.geometry);
+  const isOriginal = (desktop === originalStruct.desktop) && (geometry === originalStruct.geometry);
 
-  return <Button color="success" className="pull-right" disabled={request.loading || is_original} onClick={submit}>
+  return <Button color="success" className="pull-right" disabled={request.loading || isOriginal} onClick={submit}>
     { request.loading ? <i className="fa fa-spinner fa-spin mr-1"/> : null }
-    <span>{request.loading ? "Updating Configuration..." : "Update Configuration"}</span>
+    <span>{request.loading ? "Updating..." : "Update Your Configuration"}</span>
   </Button>
 }
 
@@ -167,7 +167,7 @@ function updateFailedToast({ errorCode }) {
   return {
     body,
     icon: 'danger',
-    header: 'Failed to update configuration',
+    header: 'Failed to update your configuration',
   };
 }
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -21,7 +21,7 @@ function ConfigsPage() {
   const desktop_req = useFetchDesktops();
 
   if (config_req.error || desktop_req.error) {
-    req = (config_req.error ? config_req : desktop_req)
+    const req = (config_req.error ? config_req : desktop_req)
     if (utils.errorCode(req.data) === 'Unauthorized') {
       return <UnauthorizedError />;
     } else {
@@ -31,13 +31,18 @@ function ConfigsPage() {
     if (config_req.loading || desktop_req.loading) {
       return <Loading />;
     } else {
-      return <Layout configs={config_req.data} />
+      return <Layout configs={config_req.data} desktops={desktop_req.data.data} />
     }
   }
 }
 
-function Layout({ configs }) {
+function Layout({ configs, desktops }) {
+  // Determine the current settings
   const [x, y] = configs.geometry.split("x");
+  const d = desktops.map(d => { return d.id }).includes(configs.desktop) ? configs.desktop : null;
+
+  // Create the state references
+  const [desktop, setDesktop] = useState(d);
   const [xGeometry, setXGeometry] = useState(x);
   const [yGeometry, setYGeometry] = useState(y);
 
@@ -63,9 +68,14 @@ function Layout({ configs }) {
           <FormGroup row>
             <Label for="desktop" sm={2} size="lg">Desktop</Label>
             <Col>
-              <Input  type="text" name="desktop" id="desktop"
-                      placeholder={configs.desktop} value={configs.desktop} required
-              />
+              <Input  type="select" name="desktop" id="desktop" required
+                      value={desktop} onChange={e => setDesktop(e.target.value)}>
+                {desktops.map(desktop => {
+                  if (desktop.verified) {
+                    return (<option>{desktop.id}</option>);
+                  }
+                })}
+              </Input>
             </Col>
           </FormGroup>
           <FormGroup row>

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -1,18 +1,15 @@
 import React, { useState } from 'react';
-import classNames from 'classnames';
 
-import { Button, Form, FormGroup, Col, Label, Input, FormText } from 'reactstrap';
+import { Button, Form, FormGroup, Col, Label, Input } from 'reactstrap';
 
 import {
   Overlay,
-  OverlayContainer,
   Spinner,
   UnauthorizedError,
   DefaultErrorMessage,
   utils,
 } from 'flight-webapp-components';
 
-import styles from './SessionsPage.module.css';
 import { useFetchUserConfig, useFetchDesktops, useUpdateUserConfig } from './api';
 import { useToast } from './ToastContext';
 
@@ -76,9 +73,11 @@ function Layout({ configs, desktops }) {
               <Input  type="select" name="desktop" id="desktop" required
                       value={desktop} onChange={e => updater(setDesktop, e)}>
                 {desktops.map(desktop => {
+                  var element = null;
                   if (desktop.verified) {
-                    return (<option>{desktop.id}</option>);
+                    element = <option key={desktop.id}>{desktop.id}</option>
                   }
+                  return element;
                 })}
               </Input>
             </Col>
@@ -118,7 +117,7 @@ function UpdateButton({desktop, geometry, modified, setModified}) {
     // Create the submitter
     const data = await patch(desktop, geometry);
     if (request.response.ok) {
-      if ( desktop == data.desktop && geometry == data.geometry) {
+      if ( desktop === data.desktop && geometry === data.geometry) {
         // Update successful
         setModified(false);
       } else {

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -98,7 +98,7 @@ function DesktopOptions({desktops, selected, original}) {
     const pretty  = prettyDesktopName[desktop.id];
     const label = original === desktop.id ? `${pretty} (default)` : pretty
     if (desktop.verified) {
-      element = <option value={desktop.id} label={label} selected={is_selected}/>
+      element = <option key={desktop.id} value={desktop.id} label={label} selected={is_selected}/>
     }
     return element;
   });
@@ -108,7 +108,7 @@ function GeometryOptions({geometries, selected, original}) {
   return geometries.map(geometry => {
     const is_selected = (selected === geometry);
     const label = original === geometry ? `${original} (default)` : geometry
-    return <option value={geometry} label={label} selected={is_selected}/>
+    return <option key={geometry} value={geometry} label={label} selected={is_selected}/>
   });
 }
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -1,4 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+
+import { Button, Form, FormGroup, Col, Label, Input, FormText } from 'reactstrap';
 
 import {
   Overlay,
@@ -9,6 +12,7 @@ import {
   utils,
 } from 'flight-webapp-components';
 
+import styles from './SessionsPage.module.css';
 import { useFetchUserConfig } from './api';
 import { useInterval } from './utils';
 
@@ -32,6 +36,10 @@ function ConfigsPage() {
 }
 
 function Layout({ configs }) {
+  const [x, y] = configs.geometry.split("x");
+  const [xGeometry, setXGeometry] = useState(x);
+  const [yGeometry, setYGeometry] = useState(y);
+
   if (configs == null) {
     console.log("The 'configs' where null")
     return <DefaultErrorMessage />;
@@ -50,20 +58,30 @@ function Layout({ configs }) {
         </span>
       </h4>
       <div className="card-body">
-        <dl>
-          <dt
-            className="text-truncate"
-            title="Desktop"
-          >
-            Desktop
-          </dt>
-          <dd
-            className="text-truncate"
-            title={configs.desktop}
-          >
-            {configs.desktop}
-          </dd>
-        </dl>
+        <Form>
+          <FormGroup row>
+            <Label for="desktop" sm={2} size="lg">Desktop</Label>
+            <Col>
+              <Input  type="text" name="desktop" id="desktop"
+                      placeholder={configs.desktop} value={configs.desktop} required
+              />
+            </Col>
+          </FormGroup>
+          <FormGroup row>
+            <Label sm={2} size="lg">Geometry</Label>
+            <Col>
+              <Input  type="number" name="geometry-x" id="geometry-x" required
+                      placeholder="X Geometry" value={xGeometry} onChange={e => setXGeometry(e.target.value)}
+              />
+            </Col>
+            <span sm="auto" size="lg" className="align-middle">X</span>
+            <Col>
+              <Input  type="number" name="geometry-y" id="geometry-y" required
+                      placeholder="Y Geometry" value={yGeometry} onChange={e => setYGeometry(e.target.value)}
+              />
+            </Col>
+          </FormGroup>
+        </Form>
       </div>
     </div>
   );

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -10,6 +10,8 @@ import {
   utils,
 } from 'flight-webapp-components';
 
+import { prettyDesktopName } from './utils';
+
 import { useFetchUserConfig, useFetchDesktops, useUpdateUserConfig } from './api';
 import { useToast } from './ToastContext';
 
@@ -108,7 +110,7 @@ function DesktopOptions({desktops, selected}) {
   return desktops.map(desktop => {
     var element = null;
     if (desktop.verified) {
-      element = <option key={desktop.id} selected={selected === desktop.id}>{desktop.id}</option>
+      element = <option value={desktop.id} label={prettyDesktopName[desktop.id]} selected={selected === desktop.id}/>
     }
     return element;
   });

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -137,8 +137,9 @@ function UpdateButton({desktop, geometry, modified, setModified}) {
     }
   }
 
-  return <Button color="success" className="pull-right" disabled={!modified} onClick={submit}>
-    Update Configuration
+  return <Button color="success" className="pull-right" disabled={request.loading || !modified} onClick={submit}>
+    { request.loading ? <i className="fa fa-spinner fa-spin mr-1"/> : null }
+    <span>{request.loading ? "Updating Configuration..." : "Update Configuration"}</span>
   </Button>
 }
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -120,6 +120,7 @@ function UpdateButton({desktop, geometry, modified, setModified}) {
       if ( desktop === data.desktop && geometry === data.geometry) {
         // Update successful
         setModified(false);
+        addToast(updateSuccessfulToast());
       } else {
         // The API response does not match the expected values
         addToast(updateFailedToast({ errorCode: "did-not-update" }));
@@ -133,6 +134,20 @@ function UpdateButton({desktop, geometry, modified, setModified}) {
   return <Button color="success" className="pull-right" disabled={!modified} onClick={submit}>
     Update Configuration
   </Button>
+}
+
+function updateSuccessfulToast() {
+  let body = (
+    <div>
+      Your configurations have been updated!
+    </div>
+  );
+
+  return {
+    body,
+    icon: 'success',
+    header: 'Updated your configurations',
+  };
 }
 
 function updateFailedToast({ errorCode }) {

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Button, Form, FormGroup, Col, Label, Input } from 'reactstrap';
+import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
 
 import {
   Overlay,
@@ -69,28 +69,22 @@ function Layout({ configs, desktops }) {
       </h4>
       <div className="card-body container">
         <Form>
-          <FormGroup row>
-            <Label for="desktop" sm={2} size="lg">Desktop</Label>
-            <Col>
-              <Input  type="select" name="desktop" id="desktop" required
-                      value={desktop} onChange={e => updater(setDesktop, e)}>
-                <DesktopOptions desktops={desktops} default={desktop} />
-              </Input>
-            </Col>
+          <FormGroup>
+            <Label for="desktop">Desktop</Label>
+            <Input  type="select" name="desktop" id="desktop" required
+                    value={desktop} onChange={e => updater(setDesktop, e)}>
+              <DesktopOptions desktops={desktops} default={desktop} />
+            </Input>
           </FormGroup>
-          <FormGroup row>
-            <Label sm={2} size="lg">Geometry</Label>
-            <Col>
-              <Input  type="number" name="geometry-x" id="geometry-x" required
-                      placeholder="X Geometry" value={xGeometry} onChange={e => updater(setXGeometry, e)}
-              />
-            </Col>
+          <FormGroup>
+            <Label>Geometry</Label>
+            <Input  type="number" name="geometry-x" id="geometry-x" required
+                    placeholder="X Geometry" value={xGeometry} onChange={e => updater(setXGeometry, e)}
+            />
             <span sm="auto" size="lg" className="align-middle">X</span>
-            <Col>
-              <Input  type="number" name="geometry-y" id="geometry-y" required
-                      placeholder="Y Geometry" value={yGeometry} onChange={e => updater(setYGeometry, e)}
-              />
-            </Col>
+            <Input  type="number" name="geometry-y" id="geometry-y" required
+                    placeholder="Y Geometry" value={yGeometry} onChange={e => updater(setYGeometry, e)}
+            />
           </FormGroup>
           <FormGroup check>
             <UpdateButton

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -1,17 +1,15 @@
 import React, { useState } from 'react';
-
 import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
 
 import {
+  DefaultErrorMessage,
   Overlay,
   Spinner,
   UnauthorizedError,
-  DefaultErrorMessage,
   utils,
 } from 'flight-webapp-components';
 
 import { prettyDesktopName } from './utils';
-
 import { useFetchUserConfig, useFetchDesktops, useUpdateUserConfig } from './api';
 import { useToast } from './ToastContext';
 
@@ -47,7 +45,6 @@ function Layout({ configs, desktops }) {
   const [geometry, setGeometry] = useState(originalStruct.geometry);
 
   if (configs == null) {
-    console.log("The 'configs' where null")
     return <DefaultErrorMessage />;
   }
 
@@ -65,16 +62,28 @@ function Layout({ configs, desktops }) {
         <Form>
           <FormGroup>
             <Label for="desktop">Desktop</Label>
-            <Input  type="select" name="desktop" id="desktop" required
-                    value={desktop} onChange={e => setDesktop(e.target.value)}>
-              <DesktopOptions desktops={desktops} selected={desktop} original={originalStruct.desktop}/>
+            <Input
+              id="desktop"
+              name="desktop"
+              onChange={e => setDesktop(e.target.value)}
+              required
+              type="select"
+              value={desktop}
+            >
+              <DesktopOptions desktops={desktops} original={originalStruct.desktop} />
             </Input>
           </FormGroup>
           <FormGroup>
             <Label>Geometry</Label>
-            <Input  type="select" name="geometry" id="geometry" required
-                    value={geometry} onChange={e => { setGeometry(e.target.value) }}>
-              <GeometryOptions geometries={configs.geometries} selected={geometry} original={originalStruct.geometry}/>
+            <Input
+              id="geometry"
+              name="geometry"
+              onChange={e => { setGeometry(e.target.value) }}
+              required
+              type="select"
+              value={geometry}
+            >
+              <GeometryOptions geometries={configs.geometries} original={originalStruct.geometry} />
             </Input>
           </FormGroup>
           <FormGroup check>
@@ -91,27 +100,36 @@ function Layout({ configs, desktops }) {
   );
 }
 
-function DesktopOptions({desktops, selected, original}) {
+function DesktopOptions({desktops, original}) {
   return desktops.map(desktop => {
-    var label = prettyDesktopName[desktop.id];
+    let label = prettyDesktopName[desktop.id];
     if (original === desktop.id) {
       label = `${label} (default)`
     }
     if (!desktop.verified) {
-      label = `${label} - (Disabled: Unverified)`
+      label = `${label} - (Unverified)`
     }
-    return <option  key={desktop.id}
-                    value={desktop.id}
-                    label={label}
-                    selected={selected}
-                    disabled={!desktop.verified}/>
+    return (
+      <option
+        disabled={!desktop.verified}
+        key={desktop.id}
+        label={label}
+        value={desktop.id}
+      />
+    );
   });
 }
 
-function GeometryOptions({geometries, selected, original}) {
+function GeometryOptions({geometries, original}) {
   return geometries.map(geometry => {
     const label = original === geometry ? `${original} (default)` : geometry
-    return <option key={geometry} value={geometry} label={label} selected={selected}/>
+    return (
+      <option
+        key={geometry}
+        label={label}
+        value={geometry}
+      />
+    );
   });
 }
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -72,13 +72,8 @@ function Layout({ configs, desktops }) {
             <Col>
               <Input  type="select" name="desktop" id="desktop" required
                       value={desktop} onChange={e => updater(setDesktop, e)}>
-                {desktops.map(desktop => {
-                  var element = null;
-                  if (desktop.verified) {
-                    element = <option key={desktop.id}>{desktop.id}</option>
-                  }
-                  return element;
-                })}
+                <DisabledDesktopOption desktops={desktops} desktop={configs.desktop}/>
+                <DesktopOptions desktops={desktops}/>
               </Input>
             </Col>
           </FormGroup>
@@ -108,6 +103,26 @@ function Layout({ configs, desktops }) {
       </div>
     </div>
   );
+}
+
+function DisabledDesktopOption({desktops, desktop}) {
+  // Checks if the desktop exists and is verified
+  if (desktops.includes(d => { return d.id === desktop && d.verified })) {
+    return;
+  }
+
+  // Returns the disabled element
+  return(<option key={desktop} disabled>{desktop}</option>);
+}
+
+function DesktopOptions({desktops}) {
+  return desktops.map(desktop => {
+    var element = null;
+    if (desktop.verified) {
+      element = <option key={desktop.id}>{desktop.id}</option>
+    }
+    return element;
+  });
 }
 
 function UpdateButton({desktop, geometry, modified, setModified}) {

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -94,11 +94,10 @@ function Layout({ configs, desktops }) {
 function DesktopOptions({desktops, selected, original}) {
   return desktops.map(desktop => {
     var element = null;
-    const is_selected = (selected === desktop.id);
     const pretty  = prettyDesktopName[desktop.id];
     const label = original === desktop.id ? `${pretty} (default)` : pretty
     if (desktop.verified) {
-      element = <option key={desktop.id} value={desktop.id} label={label} selected={is_selected}/>
+      element = <option key={desktop.id} value={desktop.id} label={label} selected={selected}/>
     }
     return element;
   });
@@ -106,9 +105,8 @@ function DesktopOptions({desktops, selected, original}) {
 
 function GeometryOptions({geometries, selected, original}) {
   return geometries.map(geometry => {
-    const is_selected = (selected === geometry);
     const label = original === geometry ? `${original} (default)` : geometry
-    return <option key={geometry} value={geometry} label={label} selected={is_selected}/>
+    return <option key={geometry} value={geometry} label={label} selected={selected}/>
   });
 }
 

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -118,13 +118,13 @@ function Layout({ configs, desktops }) {
 }
 
 function UpdateButton({desktop, geometry, modified, onSubmitted}) {
-  const { patch, response, error } = useUpdateUserConfig(desktop, geometry);
+  const { request, patch } = useUpdateUserConfig();
   console.log("Rendering button");
   console.log(desktop);
   const submit = async() => {
     // Create the submitter
-    const data = await patch();
-    if (response.ok) {
+    const data = await patch(desktop, geometry);
+    if (request.response.ok) {
       onSubmitted(data);
     } else {
       console.log("Failed to update");

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -36,7 +36,7 @@ function ConfigsPage() {
 function Layout({ configs, desktops }) {
   // Determine the current settings
   const [x, y] = configs.geometry.split("x");
-  const d = desktops.map(d => { return d.id }).includes(configs.desktop) ? configs.desktop : null;
+  const d = desktops.map(d => d.id).includes(configs.desktop) ? configs.desktop : null;
 
   // Create the state references
   const [desktop, setDesktop] = useState(d);

--- a/src/ConfigsPage.js
+++ b/src/ConfigsPage.js
@@ -154,21 +154,21 @@ function UpdateButton({desktop, geometry, modified, setModified}) {
 function updateSuccessfulToast() {
   let body = (
     <div>
-      Your configurations have been updated!
+      Your configuration has been updatede.
     </div>
   );
 
   return {
     body,
     icon: 'success',
-    header: 'Updated your configurations',
+    header: 'Updated your configuration',
   };
 }
 
 function updateFailedToast({ errorCode }) {
   let body = (
     <div>
-      Unfortunately there has been a problem updating your configurations.
+      Unfortunately there has been a problem updating your configuration.
       Please try again and, if problems persist, help us to more quickly
       rectify the problem by contacting us and letting us know.
     </div>
@@ -177,7 +177,7 @@ function updateFailedToast({ errorCode }) {
   return {
     body,
     icon: 'danger',
-    header: 'Failed to update configurations',
+    header: 'Failed to update configuration',
   };
 }
 

--- a/src/ConfigsPage.module.css
+++ b/src/ConfigsPage.module.css
@@ -1,0 +1,7 @@
+.FormLabel {
+    float: left;
+    width: 9em;
+    margin-right: 0.5em;
+}
+.MetadataEntryDD {
+}

--- a/src/NavItems.js
+++ b/src/NavItems.js
@@ -36,6 +36,9 @@ function NavItems() {
       </Link>
     </li>
     <li className="nav-item">
+      <QuickLaunchButton className="nav-link nav-menu-button" color="link"/>
+    </li>
+    <li className="nav-item">
       <Link
         className="nav-link nav-menu-button"
         to="/sessions/new"
@@ -51,7 +54,6 @@ function NavItems() {
         My Configuration
       </Link>
     </li>
-    <QuickLaunchButton/>
     </>
   );
 }

--- a/src/NavItems.js
+++ b/src/NavItems.js
@@ -41,6 +41,14 @@ function NavItems() {
         Launch new session
       </Link>
     </li>
+    <li className="nav-item">
+      <Link
+        className="nav-link nav-menu-button"
+        to="/configs"
+      >
+        My Configuration
+      </Link>
+    </li>
     </>
   );
 }

--- a/src/NavItems.js
+++ b/src/NavItems.js
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 
 import { CurrentUserContext, useEnvironment } from 'flight-webapp-components';
 
+import QuickLaunchButton from './QuickLaunchButton'
+
 function NavItems() {
   const { currentUser } = useContext(CurrentUserContext);
   const environment = useEnvironment();
@@ -49,6 +51,7 @@ function NavItems() {
         My Configuration
       </Link>
     </li>
+    <QuickLaunchButton/>
     </>
   );
 }

--- a/src/QuickLaunchButton.js
+++ b/src/QuickLaunchButton.js
@@ -6,7 +6,7 @@ import { useLaunchDefaultSession } from './api';
 import { ConfigContext } from 'flight-webapp-components';
 import { Button } from 'reactstrap';
 
-function QuickLaunchButton() {
+function QuickLaunchButton({ className, color }) {
   const clusterName = useContext(ConfigContext).clusterName;
   const history = useHistory();
   const { addToast } = useToast();
@@ -22,8 +22,8 @@ function QuickLaunchButton() {
     });
   };
 
-  return <Button color="success" disabled={loading} onClick={submit}>
-    Launch Session
+  return <Button className={className} color={color} disabled={loading} onClick={submit}>
+    Quick launch session
   </Button>
 }
 

--- a/src/QuickLaunchButton.js
+++ b/src/QuickLaunchButton.js
@@ -23,7 +23,8 @@ function QuickLaunchButton({ className, color }) {
   };
 
   return <Button className={className} color={color} disabled={loading} onClick={submit}>
-    Quick launch session
+    { loading ? <i className="fa fa-spinner fa-spin mr-1"/> : null }
+    <span>{ loading ? "Quick lauching session..." : "Quick launch session" }</span>
   </Button>
 }
 

--- a/src/QuickLaunchButton.js
+++ b/src/QuickLaunchButton.js
@@ -1,0 +1,47 @@
+import { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useToast } from './ToastContext';
+import { useLaunchDefaultSession } from './api';
+
+import { ConfigContext } from 'flight-webapp-components';
+import { Button } from 'reactstrap';
+
+function QuickLaunchButton() {
+  const clusterName = useContext(ConfigContext).clusterName;
+  const history = useHistory();
+  const { addToast } = useToast();
+  const { response, loading, post } = useLaunchDefaultSession();
+
+  const submit = () => {
+    post().then((responseBody) => {
+      if (response.ok) {
+        history.push(`/sessions/${responseBody.id}`);
+      } else {
+        addToast(failedToast(clusterName));
+      }
+    });
+  };
+
+  return <Button color="success" disabled={loading} onClick={submit}>
+    Launch Session
+  </Button>
+}
+
+function failedToast(clusterName) {
+  const body = (
+    <div>
+      Your default desktop has not yet been fully configured.  If
+      you would like to use this desktop please contact the system
+      administrator for {' '}<em>{clusterName}</em> and ask them to prepare
+      this desktop.
+    </div>
+  );
+
+  return {
+    body,
+    icon: 'danger',
+    header: 'Failed to launch desktop',
+  };
+}
+
+export default QuickLaunchButton;

--- a/src/api.js
+++ b/src/api.js
@@ -83,7 +83,7 @@ export function useTerminateSession(id) {
   return request;
 }
 
-export function useUpdateUserConfig(desktop, geometry) {
+export function useUpdateUserConfig() {
   const request = useFetch(
     '/configs/user',
     {
@@ -92,13 +92,12 @@ export function useUpdateUserConfig(desktop, geometry) {
         'Content-Type': 'application/json',
         'Accepts': 'application/json',
       },
-      body: {
-        desktop: desktop,
-        geometry: geometry
-      },
       cachePolicy: 'no-cache',
     });
-  return request;
+  const patch = function(desktop, geometry) {
+    return request.patch({ desktop: desktop, geometry: geometry });
+  }
+  return { request, patch: patch };
 }
 
 export function useFetchScreenshot(id, { reloadInterval=1*60*1000 }={}) {

--- a/src/api.js
+++ b/src/api.js
@@ -21,6 +21,14 @@ export function useFetchSessions() {
     [ currentUser.authToken ]);
 }
 
+export function useFetchUserConfig() {
+  const { currentUser } = useContext(CurrentUserContext);
+  return useFetch(
+    "/configs/user",
+    { headers: { Accept: 'application/json' } },
+    [ currentUser.authToken ]);
+}
+
 export function useFetchSession(id) {
   const { currentUser } = useContext(CurrentUserContext);
   return useFetch(`/sessions/${id}`, [ id, currentUser.authToken ]);

--- a/src/api.js
+++ b/src/api.js
@@ -111,7 +111,7 @@ export function useUpdateUserConfig() {
   const patch = function(desktop, geometry) {
     return request.patch({ desktop: desktop, geometry: geometry });
   }
-  return { request, patch: patch };
+  return { request, patch };
 }
 
 export function useFetchScreenshot(id, { reloadInterval=1*60*1000 }={}) {

--- a/src/api.js
+++ b/src/api.js
@@ -83,6 +83,24 @@ export function useTerminateSession(id) {
   return request;
 }
 
+export function useUpdateUserConfig(desktop, geometry) {
+  const request = useFetch(
+    '/configs/user',
+    {
+      method: 'patch',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accepts': 'application/json',
+      },
+      body: {
+        desktop: desktop,
+        geometry: geometry
+      },
+      cachePolicy: 'no-cache',
+    });
+  return request;
+}
+
 export function useFetchScreenshot(id, { reloadInterval=1*60*1000 }={}) {
   const lastLoadedAt = useRef(null);
   const [ image, setImage ] = useState(null);

--- a/src/api.js
+++ b/src/api.js
@@ -34,6 +34,20 @@ export function useFetchSession(id) {
   return useFetch(`/sessions/${id}`, [ id, currentUser.authToken ]);
 }
 
+export function useLaunchDefaultSession() {
+  const request = useFetch(
+    "/sessions",
+    {
+      method: 'post',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      cachePolicy: 'no-cache',
+    });
+  return request;
+}
+
 export function useLaunchSession(desktop) {
   const request = useFetch(
     "/sessions",

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import Dashboard from './Dashboard';
 import DesktopsPage from './DesktopsPage';
 import SessionPage from './SessionPage';
 import SessionsPage from './SessionsPage';
+import ConfigsPage from './ConfigsPage';
 import UnconfiguredDashboard from './UnconfiguredDashboard';
 
 // We need this to prevent the route for `/sessions/:id` from matching the
@@ -29,6 +30,13 @@ const routes = [
     path: '/sessions',
     name: 'Sessions',
     Component: SessionsPage,
+    authenticated: true,
+    sideNav: true,
+  },
+  {
+    path: '/configs',
+    name: 'Configs',
+    Component: ConfigsPage,
     authenticated: true,
     sideNav: true,
   },


### PR DESCRIPTION
There is a new page under `/configs` which allows the user to update their configuration. This will poll for the current list of verified `desktop` types and display them in a list. There is some special handling when the default desktop has not been verified.

In addition, a `Quick launch session` button/link has been added to the nav bar. Currently it will re-create a session each time the user connects. Possible this should be extended to re-connect to an existing session.