### PR TITLE
Improve hiding of unverified desktop

### DIFF
--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -7,7 +7,6 @@ import {
   utils,
 } from 'flight-webapp-components';
 
-import styles from './DesktopCard.module.css';
 import { CardFooter } from './CardParts';
 import { prettyDesktopName } from './utils';
 import { useLaunchSession } from './api';
@@ -36,7 +35,7 @@ function DesktopCard({ desktop }) {
   return (
     <div
       className={
-        classNames('card border-primary mb-2', { [styles.DesktopUnverified]: !desktop.verified })
+        classNames('card border-primary mb-2')
       }
     >
       <h5
@@ -68,8 +67,6 @@ function DesktopCard({ desktop }) {
               classNames("btn btn-sm btn-primary mr-2", { 'disabled': loading })
             }
             onClick={launchSession}
-            disabled={!desktop.verified || loading}
-            title={desktop.verified ? null : unverifiedMessage(clusterName)}
           >
             {
               loading ?
@@ -81,14 +78,6 @@ function DesktopCard({ desktop }) {
         </div>
       </CardFooter>
     </div>
-  );
-}
-
-function unverifiedMessage(clusterName) {
-  return (
-    "This desktop has not yet been fully configured. If you would like to use" +
-    ` this desktop please contact the system administrator for ${clusterName}` +
-    " and ask them to prepare this desktop."
   );
 }
 

--- a/src/DesktopCard.module.css
+++ b/src/DesktopCard.module.css
@@ -1,3 +1,0 @@
-.DesktopUnverified > * {
-    opacity: 0.5;
-}

--- a/src/DesktopsPage.js
+++ b/src/DesktopsPage.js
@@ -45,18 +45,31 @@ function DesktopsPage() {
 
 function DesktopsList({ desktops }) {
   const filteredDesktops = desktops.filter(desktop => desktop.verified);
-  const { groupedItems: groupedDesktops } = useMediaGrouping(
+  const { groupedItems: groupedDesktops, perGroup } = useMediaGrouping(
     ['(min-width: 1200px)', '(min-width: 992px)', '(min-width: 768px)', '(min-width: 576px)'],
     [3, 2, 2, 1],
     1,
     filteredDesktops,
   );
   const decks = groupedDesktops.map(
-    (group, index) => (
-      <div key={index} className="card-deck">
-        {group.map((desktop) => <DesktopCard key={desktop.id} desktop={desktop} />)}
-      </div>
-    )
+    (group, index) => {
+      let blanks = null;
+      if ( group.length < perGroup) {
+        const a = new Array(perGroup - group.length);
+        a.fill(0);
+        blanks = a.map((i, index) => <div key={index} className="card invisible"></div>)
+      }
+      return (
+        <div key={index} className="card-deck">
+          {
+            group.map((desktop) => (
+              <DesktopCard key={desktop.id} desktop={desktop} />
+            ))
+          }
+          {blanks}
+        </div>
+      );
+    }
   );
 
   return (

--- a/src/DesktopsPage.js
+++ b/src/DesktopsPage.js
@@ -44,11 +44,12 @@ function DesktopsPage() {
 }
 
 function DesktopsList({ desktops }) {
+  const filteredDesktops = desktops.filter(desktop => desktop.verified);
   const { groupedItems: groupedDesktops } = useMediaGrouping(
     ['(min-width: 1200px)', '(min-width: 992px)', '(min-width: 768px)', '(min-width: 576px)'],
     [3, 2, 2, 1],
     1,
-    desktops,
+    filteredDesktops,
   );
   const decks = groupedDesktops.map(
     (group, index) => (


### PR DESCRIPTION
This PR introduces some changes to the way that Flight Desktop Webapp displays (or rather, doesn't display) unverified desktops. Previously, unverified desktops were rendered on the page. The user could decide what they looked like via the custom branding functionality. However, hiding unverified desktops with `display: none;` meant that the grid-ish layout of the cards was disrupted by invisible nodes. This PR changes the page's React component such that unverified desktops are no longer rendered at all. An additional change included adds invisible cards to the page so that a single desktop card does not take up more space than is necessary.

For example, a desktops page with 5 verified desktops and 1 unverified desktop will look like this:
![Screenshot_2022-02-23_11-09-25](https://user-images.githubusercontent.com/12374447/155308235-01e51f28-414d-4ec5-9a9d-3ff9ed286628.png)

