### PR TITLE
Remove superfluous brandbar and productbar

### DIFF
--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -7,7 +7,6 @@ import {
   BrandBar,
   ConfigContext,
   Footer,
-  ProductBar,
 } from 'flight-webapp-components';
 
 import NavItems from './NavItems';
@@ -20,11 +19,9 @@ function AppLayout() {
   return (
     <>
     <BrandBar
-      className="brandbar brandbar-combined"
+      className="brandbar"
       navItems={<NavItems includeHome={false} />}
     />
-    <BrandBar className="brandbar" />
-    <ProductBar navItems={<NavItems />} />
     <div
       className="container-fluid"
       id="main"


### PR DESCRIPTION
This PR is part of a set of work that aims to remove the product bar from webapps, and merge the nav items that it contained into the brandbar.

This PR stops importing and rendering the ProductBar component, and stops rendering the .brandbar-combined and ProductBar components.
