### PR TITLE
Pass custom items into account menu

### DIFF
--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -15,12 +15,22 @@ import { routes, unconfiguredRoutes } from './routes';
 
 function AppLayout() {
   const { unconfigured } = useContext(ConfigContext);
+  const accountMenuItems = {
+    signedIn: [
+      {
+        "href": "/configs",
+        "text": "Configuration"
+      }
+    ]
+  }
+
 
   return (
     <>
     <BrandBar
       className="brandbar"
       navItems={<NavItems includeHome={false} />}
+      accountMenuItems={accountMenuItems}
     />
     <div
       className="container-fluid"

--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Redirect, Route, Switch, useLocation } from "react-router-dom";
+import { Link, Redirect, Route, Switch, useLocation } from "react-router-dom";
 
 import {
   AnimatedRouter,
@@ -17,10 +17,9 @@ function AppLayout() {
   const { unconfigured } = useContext(ConfigContext);
   const accountMenuItems = {
     signedIn: [
-      {
-        "href": "/configs",
-        "text": "Configuration"
-      }
+      <Link to="/configs" className="nav nav-link dropdown-item">
+        Configuration
+      </Link>
     ]
   }
 

--- a/src/NavItems.js
+++ b/src/NavItems.js
@@ -21,7 +21,6 @@ function NavItems({ includeHome=true }) {
     <li className="nav-item dropdown">
       <LaunchDropdown className="nav-link nav-menu-button" color="link"/>
     </li>
-    <NavLink path="/configs">Configuration</NavLink>
     </>
   );
 }


### PR DESCRIPTION
This PR makes a change to the way that the `My configuration` nav item is rendered. It has been removed from the `NavItems` function, and is now passed into `flight-webapp-components` to be rendered as part of the `AccountMenu` dropdown (see https://github.com/openflighthpc/flight-webapp-components/pull/9 for the the `flight-webapp-components` enhancement which allows this).