### PR TITLE
Display desktop name alongside ID

### DIFF
--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -18,7 +18,9 @@ function timestampFormat(timestamp) {
 
 function SessionCard({ reload, session }) {
   const sessionId = session.id.split('-')[0];
-  const sessionName = session.name == null ? '' : `(${session.name})`;
+  const title = session.name == null ?
+    sessionId :
+    `${session.name} (${sessionId})`;
   let sessionState;
   if (session.state === 'Remote') {
     sessionState = 'Active';
@@ -34,7 +36,7 @@ function SessionCard({ reload, session }) {
         data-testid="session-card"
       >
         <h5 className="card-header bg-primary text-light">
-          {sessionId} {sessionName}
+          {title}
         </h5>
         <div className={
           classNames("card-body", { 'text-muted': !activeStates.includes(session.state) })

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -17,7 +17,8 @@ function timestampFormat(timestamp) {
 }
 
 function SessionCard({ reload, session }) {
-  const sessionName = session.name || session.id.split('-')[0];
+  const sessionId = session.id.split('-')[0];
+  const sessionName = session.name == null ? '' : `(${session.name})`;
   let sessionState;
   if (session.state === 'Remote') {
     sessionState = 'Active';
@@ -33,7 +34,7 @@ function SessionCard({ reload, session }) {
         data-testid="session-card"
       >
         <h5 className="card-header bg-primary text-light">
-          {sessionName}
+          {sessionId} {sessionName}
         </h5>
         <div className={
           classNames("card-body", { 'text-muted': !activeStates.includes(session.state) })
@@ -52,6 +53,10 @@ function SessionCard({ reload, session }) {
               valueTitle={
                 prettyDesktopName[session.desktop] || session.desktop || 'Unknown'
               }
+            />
+            <MetadataEntry
+              name="Name"
+              value={session.name || 'N/A'}
             />
             <MetadataEntry
               name="State"

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -163,15 +163,14 @@ function Layout({
   session,
   vnc,
 }) {
-  // `id` could be null when we are navigating away from the page.
   const { id } = useParams();
-  const sessionId = id == null ? '' : id.split('-')[0];
-  const sessionName = (session == null || session.name === '') ?
-    null :
-    `(${session.name})`;
+  const sessionId = id.split('-')[0];
   const hostname = session == null ?
     null :
     <span>running on <code className="text-reset">{session.hostname}</code></span>;
+  const title = (session == null || session.name == null || session.name === "") ?
+    <span>{sessionId} {hostname}</span> :
+    <span>{session.name} ({sessionId}) {hostname}</span>;
 
   return (
     <div className="overflow-auto">
@@ -183,7 +182,7 @@ function Layout({
                 <div className="col">
                   <div className="d-flex flex-wrap align-items-center">
                     <h5 className="flex-grow-1 mb-0">
-                      {sessionId} {sessionName} {hostname}
+                      {title}
                     </h5>
                     <Toolbar
                       connectionState={connectionState}

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -165,7 +165,10 @@ function Layout({
 }) {
   // `id` could be null when we are navigating away from the page.
   const { id } = useParams();
-  const sessionName = id == null ? '' : id.split('-')[0];
+  const sessionId = id == null ? '' : id.split('-')[0];
+  const sessionName = (session == null || session.name === '') ?
+    null :
+    `(${session.name})`;
   const hostname = session == null ?
     null :
     <span>running on <code className="text-reset">{session.hostname}</code></span>;
@@ -180,7 +183,7 @@ function Layout({
                 <div className="col">
                   <div className="d-flex flex-wrap align-items-center">
                     <h5 className="flex-grow-1 mb-0">
-                      {sessionName} {hostname}
+                      {sessionId} {sessionName} {hostname}
                     </h5>
                     <Toolbar
                       connectionState={connectionState}


### PR DESCRIPTION
This PR changes the session index page and the session connection page to display the newly realised `name` property, where applicable.