### PR TITLE
Naming/renaming sessions

### DIFF
--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import {
-} from 'flight-webapp-components';
-
 import { CardFooter } from './CardParts';
 import LaunchDesktopButton from './LaunchDesktopButton';
 import { prettyDesktopName } from './utils';
@@ -46,40 +43,11 @@ function DesktopCard({ desktop }) {
             size="sm"
             className="mr-2"
             desktop={desktop}
-            errorToast={launchErrorToast}
           />
         </div>
       </CardFooter>
     </div>
   );
-}
-
-function launchErrorToast({ clusterName, desktop, launchError }) {
-  const desktopName = prettyDesktopName[desktop.id];
-  let body = (
-    <div>
-      Unfortunately there has been a problem launching your
-      {' '}<strong>{desktopName}</strong> desktop session.  Please try
-      again and, if problems persist, help us to more quickly rectify the
-      problem by contacting us and letting us know.
-    </div>
-  );
-  if (launchError === 'Desktop Not Prepared') {
-    body = (
-      <div>
-        <strong>{desktopName}</strong> has not yet been fully configured.  If
-        you would like to use this desktop please contact the system
-        administrator for {' '}<em>{clusterName}</em> and ask them to prepare
-        this desktop.
-      </div>
-    );
-  }
-
-  return {
-    body,
-    icon: 'danger',
-    header: 'Failed to launch desktop',
-  };
 }
 
 export default DesktopCard;

--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -64,9 +64,9 @@ function DesktopCard({ desktop }) {
       <CardFooter>
         <div className="btn-toolbar justify-content-center">
           <LaunchDesktopButton
-            className={
-              classNames("btn btn-sm btn-primary mr-2", { 'disabled': loading })
-            }
+            color="primary"
+            size="sm"
+            className={ classNames("mr-2", { 'disabled': loading })  }
             desktop={desktop}
             errorToast={launchErrorToast}
             launch={launchSession}

--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -1,8 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 import {
-  ConfigContext,
 } from 'flight-webapp-components';
 
 import { CardFooter } from './CardParts';

--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -1,36 +1,15 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
-import { useHistory } from 'react-router-dom';
 
 import {
   ConfigContext,
-  utils,
 } from 'flight-webapp-components';
 
 import { CardFooter } from './CardParts';
 import LaunchDesktopButton from './LaunchDesktopButton';
 import { prettyDesktopName } from './utils';
-import { useLaunchSession } from './api';
-import { useToast } from './ToastContext';
 
 function DesktopCard({ desktop }) {
-  const { loading, post, response } = useLaunchSession(desktop);
-  const history = useHistory();
-  const { addToast } = useToast();
-  const clusterName = useContext(ConfigContext).clusterName;
-  const launchSession = () => {
-    post().then((responseBody) => {
-      if (response.ok) {
-        history.push(`/sessions/${responseBody.id}`);
-      } else {
-        addToast(launchErrorToast({
-          clusterName: clusterName,
-          desktop: desktop,
-          launchError: utils.errorCode(responseBody),
-        }));
-      }
-    });
-  };
   const desktopName = prettyDesktopName[desktop.id];
 
   return (
@@ -66,18 +45,10 @@ function DesktopCard({ desktop }) {
           <LaunchDesktopButton
             color="primary"
             size="sm"
-            className={ classNames("mr-2", { 'disabled': loading })  }
+            className="mr-2"
             desktop={desktop}
             errorToast={launchErrorToast}
-            launch={launchSession}
-          >
-            {
-              loading ?
-                <i className="fa fa-spinner fa-spin mr-1"></i> :
-                <i className="fa fa-bolt mr-1"></i>
-            }
-            <span>{ loading ? 'Launching...' : 'Launch' }</span>
-          </LaunchDesktopButton>
+          />
         </div>
       </CardFooter>
     </div>

--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -68,6 +68,8 @@ function DesktopCard({ desktop }) {
               classNames("btn btn-sm btn-primary mr-2", { 'disabled': loading })
             }
             desktop={desktop}
+            errorToast={launchErrorToast}
+            launch={launchSession}
           >
             {
               loading ?

--- a/src/DesktopCard.js
+++ b/src/DesktopCard.js
@@ -8,6 +8,7 @@ import {
 } from 'flight-webapp-components';
 
 import { CardFooter } from './CardParts';
+import LaunchDesktopButton from './LaunchDesktopButton';
 import { prettyDesktopName } from './utils';
 import { useLaunchSession } from './api';
 import { useToast } from './ToastContext';
@@ -62,11 +63,11 @@ function DesktopCard({ desktop }) {
       </div>
       <CardFooter>
         <div className="btn-toolbar justify-content-center">
-          <button
+          <LaunchDesktopButton
             className={
               classNames("btn btn-sm btn-primary mr-2", { 'disabled': loading })
             }
-            onClick={launchSession}
+            desktop={desktop}
           >
             {
               loading ?
@@ -74,7 +75,7 @@ function DesktopCard({ desktop }) {
                 <i className="fa fa-bolt mr-1"></i>
             }
             <span>{ loading ? 'Launching...' : 'Launch' }</span>
-          </button>
+          </LaunchDesktopButton>
         </div>
       </CardFooter>
     </div>

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -58,6 +58,7 @@ function LaunchDesktopButton({
   );
   const rightButton = (
     <Button
+      data-testid="session-launch-button"
       className="btn-sm ml-2"
       onClick={() => { launchSession(); toggle(); }}
   >
@@ -69,6 +70,7 @@ function LaunchDesktopButton({
   return (
     <div>
       <Button
+        data-testid="launch-modal-button"
         color={color}
         size={size}
         className={classNames(className, { 'disabled': request.loading})}

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -59,7 +59,7 @@ function LaunchDesktopButton({
       className="ml-2"
       onClick={() => { launchSession(); toggle(); }}
     >
-      Launch
+      Start
     </Button>
   );
 

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -89,9 +89,12 @@ function LaunchDesktopButton({
         leftButton={leftButton}
         rightButton={rightButton}
     >
-        Give your session a name to more easily identify it (optional)."
+        <label for="session-name">
+          Give your session a name to more easily identify it (optional).
+        </label>
         <input
-          className="w-100"
+          id="session-name"
+          className="w-100 mt-1"
           name="session-name"
           placeholder="Session name"
           type="text"

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -10,7 +10,15 @@ import ModalContainer from "./ModalContainer";
 import { useLaunchSession } from './api';
 import { prettyDesktopName } from './utils';
 
-function LaunchDesktopButton({ className, desktop, errorToast, launch, children }) {
+function LaunchDesktopButton({
+  className,
+  desktop,
+  errorToast,
+  launch,
+  children,
+  color,
+  size
+}) {
   const [modal, setModal] = useState(false);
   const toggle = () => setModal(!modal);
 
@@ -38,6 +46,8 @@ function LaunchDesktopButton({ className, desktop, errorToast, launch, children 
   return (
     <div>
       <Button
+        color={color}
+        size={size}
         className={className}
         onClick={toggle}
       >

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -25,9 +25,7 @@ function LaunchDesktopButton({
   const toggle = () => setModal(!modal);
   const clusterName = useContext(ConfigContext).clusterName;
   const desktopName = prettyDesktopName[desktop.id];
-  const modalTitle = <span>
-    Prepare launch of <i>{desktopName}</i> {desktopName.toLowerCase().endsWith('desktop') ? "" : "desktop"}
-  </span>;
+  const modalTitle = <span>Configure this session</span>
   const nameRef = useRef(null);
   const { request, post } = useLaunchSession();
   const { addToast } = useToast();

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -1,13 +1,39 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Button } from 'reactstrap';
 import { useToast } from './ToastContext';
 
-import ModalContainer from "./ModalContainer";
+import {
+  ConfigContext
+} from 'flight-webapp-components';
 
-function LaunchDesktopButton({ className, desktop, children }) {
+import ModalContainer from "./ModalContainer";
+import { useLaunchSession } from './api';
+import { prettyDesktopName } from './utils';
+
+function LaunchDesktopButton({ className, desktop, errorToast, launch, children }) {
   const [modal, setModal] = useState(false);
   const toggle = () => setModal(!modal);
-  const modalTitle = <span>Prepare launch of <i>{desktop.id}</i></span>;
+
+  const desktopName = prettyDesktopName[desktop.id];
+  const modalTitle = <span>Prepare launch of '{desktopName}' desktop</span>;
+  const leftButton = (
+    <Button
+      color="secondary"
+      onClick={toggle}
+    >
+      <i className="fa fa-chevron-left mr-1" />
+      Back
+    </Button>
+  );
+  const rightButton = (
+    <Button
+      classname="ml-2"
+      onClick={() => { launch(); toggle(); }}
+    >
+      Launch
+    </Button>
+  );
+
 
   return (
     <div>
@@ -15,13 +41,15 @@ function LaunchDesktopButton({ className, desktop, children }) {
         className={className}
         onClick={toggle}
       >
-        <i className={`fa fa-rocket mr-1`}></i>
-        <span>Launch</span>
+        {children}
       </Button>
       <ModalContainer
         isOpen={modal}
+        modalTitle={modalTitle}
         desktop={desktop}
         toggle={toggle}
+        leftButton={leftButton}
+        rightButton={rightButton}
       />
     </div>
   );

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -27,13 +27,13 @@ function LaunchDesktopButton({
   const desktopName = prettyDesktopName[desktop.id];
   const modalTitle = <span>Prepare launch of '{desktopName}' desktop</span>;
   const nameRef = useRef(null);
-  const { loading, post, response } = useLaunchSession(desktop, nameRef.current?.value);
+  const { request, post } = useLaunchSession();
   const { addToast } = useToast();
   const history = useHistory();
 
   const launchSession = () => {
-    post().then((responseBody) => {
-      if (response.ok) {
+    post(desktop.id, nameRef.current?.value).then((responseBody) => {
+      if (request.response.ok) {
         history.push(`/sessions/${responseBody.id}`);
       } else {
         addToast(errorToast({
@@ -56,7 +56,7 @@ function LaunchDesktopButton({
   );
   const rightButton = (
     <Button
-      classname="ml-2"
+      className="ml-2"
       onClick={() => { launchSession(); toggle(); }}
     >
       Launch
@@ -68,15 +68,15 @@ function LaunchDesktopButton({
       <Button
         color={color}
         size={size}
-        className={classNames(className, { 'disabled': loading})}
+        className={classNames(className, { 'disabled': request.loading})}
         onClick={toggle}
       >
         {
-          loading ?
+          request.loading ?
             <i className="fa fa-spinner fa-spin mr-1"></i> :
             <i className="fa fa-bolt mr-1"></i>
         }
-        <span>{ loading ? 'Launching...' : 'Launch' }</span>
+        <span>{ request.loading ? 'Launching...' : 'Launch' }</span>
       </Button>
       <ModalContainer
         isOpen={modal}

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -24,7 +24,6 @@ function LaunchDesktopButton({
   const [modal, setModal] = useState(false);
   const toggle = () => setModal(!modal);
   const clusterName = useContext(ConfigContext).clusterName;
-  const desktopName = prettyDesktopName[desktop.id];
   const modalTitle = <span>Configure this session</span>
   const nameRef = useRef(null);
   const { request, post } = useLaunchSession();

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -26,7 +26,7 @@ function LaunchDesktopButton({
   const clusterName = useContext(ConfigContext).clusterName;
   const desktopName = prettyDesktopName[desktop.id];
   const modalTitle = <span>
-    Prepare launch of '{desktopName}' {desktopName.toLowerCase().endsWith('desktop') ? "" : "desktop"}
+    Prepare launch of <i>'{desktopName}'</i> {desktopName.toLowerCase().endsWith('desktop') ? "" : "desktop"}
   </span>;
   const nameRef = useRef(null);
   const { request, post } = useLaunchSession();

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -26,7 +26,7 @@ function LaunchDesktopButton({
   const clusterName = useContext(ConfigContext).clusterName;
   const desktopName = prettyDesktopName[desktop.id];
   const modalTitle = <span>
-    Prepare launch of <i>'{desktopName}'</i> {desktopName.toLowerCase().endsWith('desktop') ? "" : "desktop"}
+    Prepare launch of <i>{desktopName}</i> {desktopName.toLowerCase().endsWith('desktop') ? "" : "desktop"}
   </span>;
   const nameRef = useRef(null);
   const { request, post } = useLaunchSession();
@@ -49,19 +49,20 @@ function LaunchDesktopButton({
 
   const leftButton = (
     <Button
+      className="btn-sm"
       color="secondary"
       onClick={toggle}
     >
-      <i className="fa fa-chevron-left mr-1" />
-      Back
+      Cancel
     </Button>
   );
   const rightButton = (
     <Button
-      className="ml-2"
+      className="btn-sm ml-2"
       onClick={() => { launchSession(); toggle(); }}
-    >
-      Start
+  >
+      <i className="fa fa-bolt mr-1"></i>
+      Launch
     </Button>
   );
 
@@ -87,8 +88,8 @@ function LaunchDesktopButton({
         toggle={toggle}
         leftButton={leftButton}
         rightButton={rightButton}
-      >
-        Please input a sensible name for the desktop session (you may leave this blank).
+    >
+        Give your session a name to more easily identify it (optional)."
         <input
           className="w-100"
           name="session-name"

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -11,7 +11,6 @@ import {
 
 import ModalContainer from "./ModalContainer";
 import { useLaunchSession } from './api';
-import { prettyDesktopName } from './utils';
 
 function LaunchDesktopButton({
   className,
@@ -98,6 +97,7 @@ function LaunchDesktopButton({
           placeholder="Session name"
           type="text"
           ref={nameRef}
+          autoFocus={true}
         />
       </ModalContainer>
     </div>

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -25,7 +25,9 @@ function LaunchDesktopButton({
   const toggle = () => setModal(!modal);
   const clusterName = useContext(ConfigContext).clusterName;
   const desktopName = prettyDesktopName[desktop.id];
-  const modalTitle = <span>Prepare launch of '{desktopName}' desktop</span>;
+  const modalTitle = <span>
+    Prepare launch of '{desktopName}' {desktopName.toLowerCase().endsWith('desktop') ? "" : "desktop"}
+  </span>;
   const nameRef = useRef(null);
   const { request, post } = useLaunchSession();
   const { addToast } = useToast();

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Button } from 'reactstrap';
+import { useToast } from './ToastContext';
+
+import ModalContainer from "./ModalContainer";
+
+function LaunchDesktopButton({ className, desktop, children }) {
+  const [modal, setModal] = useState(false);
+  const toggle = () => setModal(!modal);
+  const modalTitle = <span>Prepare launch of <i>{desktop.id}</i></span>;
+
+  return (
+    <div>
+      <Button
+        className={className}
+        onClick={toggle}
+      >
+        <i className={`fa fa-rocket mr-1`}></i>
+        <span>Launch</span>
+      </Button>
+      <ModalContainer
+        isOpen={modal}
+        desktop={desktop}
+        toggle={toggle}
+      />
+    </div>
+  );
+}
+
+export default LaunchDesktopButton

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -18,6 +18,7 @@ function ModalContainer({
       toggle={toggle}
       className={className}
       size={size}
+      autoFocus={false}
     >
       <ModalContent
         leftButton={leftButton}

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -16,7 +16,8 @@ function ModalContainer({
   modalTitle,
   toggle,
   leftButton,
-  rightButton
+  rightButton,
+  children
 }) {
   return (
     <Modal
@@ -29,7 +30,9 @@ function ModalContainer({
         leftButton={leftButton}
         rightButton={rightButton}
         toggle={toggle}
-        modalTitle={modalTitle}>
+        modalTitle={modalTitle}
+      >
+        {children}
       </ModalContent>
     </Modal>
   );

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -15,6 +15,8 @@ function ModalContainer({
   size="lg",
   modalTitle,
   toggle,
+  leftButton,
+  rightButton
 }) {
   return (
     <Modal
@@ -23,7 +25,40 @@ function ModalContainer({
       className={className}
       size={size}
     >
+      <ModalContent
+        leftButton={leftButton}
+        rightButton={rightButton}
+        toggle={toggle}
+        modalTitle={modalTitle}>
+      </ModalContent>
     </Modal>
+  );
+}
+
+function ModalContent({
+  children,
+  leftButton,
+  modalTitle,
+  rightButton,
+  title,
+  toggle
+}) {
+  return (
+    <React.Fragment>
+      <ModalHeader toggle={toggle} title={modalTitle}>
+        {modalTitle}
+      </ModalHeader>
+      <ModalBody>
+        <h4 className="text-truncate" title={title} >
+          {title}
+        </h4>
+        {children}
+      </ModalBody>
+      <ModalFooter>
+        {leftButton}
+        {rightButton}
+      </ModalFooter>
+    </React.Fragment>
   );
 }
 

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -1,12 +1,5 @@
 import React from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
-import {
-  DefaultErrorMessage,
-  NotFound,
-  Overlay,
-  Spinner,
-  utils,
-} from 'flight-webapp-components';
 
 function ModalContainer({
   className,

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import {
+  DefaultErrorMessage,
+  NotFound,
+  Overlay,
+  Spinner,
+  utils,
+} from 'flight-webapp-components';
+
+function ModalContainer({
+  className,
+  isOpen,
+  desktop,
+  size="lg",
+  modalTitle,
+  toggle,
+}) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      toggle={toggle}
+      className={className}
+      size={size}
+    >
+    </Modal>
+  );
+}
+
+export default ModalContainer;

--- a/src/RenameButton.js
+++ b/src/RenameButton.js
@@ -47,6 +47,17 @@ function RenameButton({
   const [ showConfirmation, setShowConfirmation] = useState(false);
   const toggle= () => setShowConfirmation(!showConfirmation);
 
+  const handleSubmit = e => {
+    renameSession();
+    toggle();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      handleSubmit();
+    }
+  };
+
   return (
     <React.Fragment>
       <Button
@@ -71,14 +82,19 @@ function RenameButton({
         </PopoverHeader>
         <PopoverBody>
           <p>
-            Enter new name (leave blank to remove the name).
+            <label for="session-name">
+              Enter new name (leave blank to remove the name).
+            </label>
             <input
+              id="session-name"
               className="w-100"
               name="session-name"
               placeholder="Session name"
               type="text"
               ref={nameRef}
-              value={session.name}
+              defaultValue={session.name}
+              onKeyDown={handleKeyDown}
+              autoFocus={true}
             />
           </p>
           <ButtonToolbar className="justify-content-center">
@@ -92,7 +108,7 @@ function RenameButton({
             <Button
               color="primary"
               className="mr-2"
-              onClick={() => {renameSession(); toggle(); }}
+              onClick={handleSubmit}
               size="sm"
             >
               <i className="fa fa-pencil-square mr-1"></i>

--- a/src/RenameButton.js
+++ b/src/RenameButton.js
@@ -71,13 +71,14 @@ function RenameButton({
         </PopoverHeader>
         <PopoverBody>
           <p>
-            Please enter a suitable name for your session (you may leave this blank).
+            Enter new name (leave blank to remove the name).
             <input
               className="w-100"
               name="session-name"
               placeholder="Session name"
               type="text"
               ref={nameRef}
+              value={session.name}
             />
           </p>
           <ButtonToolbar className="justify-content-center">

--- a/src/RenameButton.js
+++ b/src/RenameButton.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Button } from 'reactstrap';
+
+import { 
+  utils,
+} from 'flight-webapp-components';
+
+import { useRenameSession } from './api';
+
+import { prettyDesktopName } from './utils';
+import { useToast } from './ToastContext';
+
+function RenameButton({ className, session }) {
+  const { request, post } = useRenameSession(session.id);
+  const renameSession = () => {
+    post(session.id, "new-name")
+  };
+
+
+  return (
+    <Button
+      className={className}
+      session={session}
+      onClick={renameSession}
+    >
+      <i className="fa fa-pencil-square-o mr-1"></i>
+      <span>Rename</span>
+    </Button>
+  )
+}
+
+export default RenameButton;

--- a/src/RenameButton.js
+++ b/src/RenameButton.js
@@ -70,21 +70,32 @@ function RenameButton({
           Rename session
         </PopoverHeader>
         <PopoverBody>
-          rename ur session:
-          <input
-            className="w-100"
-            name="session-name"
-            placeholder="New name..."
-            type="text"
-            ref={nameRef}
-          />
+          <p>
+            Please enter a suitable name for your session (you may leave this blank).
+            <input
+              className="w-100"
+              name="session-name"
+              placeholder="Session name"
+              type="text"
+              ref={nameRef}
+            />
+          </p>
           <ButtonToolbar className="justify-content-center">
             <Button
-            className="mr-2"
-            onClick={() => {renameSession(); toggle(); }}
-            size="sm"
+              className="mr-2"
+              onClick={toggle}
+              size="sm"
             >
-              Submit
+              Cancel
+            </Button>
+            <Button
+              color="primary"
+              className="mr-2"
+              onClick={() => {renameSession(); toggle(); }}
+              size="sm"
+            >
+              <i className="fa fa-pencil-square mr-1"></i>
+              Rename
             </Button>
           </ButtonToolbar>
         </PopoverBody>
@@ -110,7 +121,7 @@ function renameFailedToast({session, errorCode}) {
   return {
     body,
     icon: 'danger',
-    header: 'Failed to terminate session',
+    header: 'Failed to rename session',
   };
 }
 

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -125,23 +125,27 @@ function MetadataEntry({ name, value, format, valueTitle }) {
 }
 
 function Buttons({ onCleaned, onTerminated, onRenamed, session }) {
+  const toolbarStyle = {
+    flexWrap: 'nowrap'
+  };
+
   if (activeStates.includes(session.state)) {
     return (
-      <div className="btn-toolbar justify-content-center">
+      <div className="btn-toolbar justify-content-center" style={toolbarStyle}>
         <Link
-          className="btn btn-sm btn-primary mr-2"
+          className="btn btn-sm btn-primary mr-2 text-nowrap"
           to={`/sessions/${session.id}`}
         >
           <i className="fa fa-bolt mr-1"></i>
           <span>Connect</span>
         </Link>
         <RenameButton
-          className="btn-sm btn-secondary mr-2"
+          className="btn-sm btn-secondary mr-2 text-nowrap"
           onRenamed={onRenamed}
           session={session}
         />
         <TerminateButton
-          className="btn-sm"
+          className="btn-sm text-nowrap"
           onTerminated={onTerminated}
           session={session}
         />

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -6,7 +6,6 @@ import { Link } from "react-router-dom";
 import CleanButton from './CleanSessionButton';
 import WrappedScreenshot from './Screenshot';
 import TerminateButton from './TerminateButton';
-import RenameButton from './RenameButton';
 import { CardFooter } from './CardParts';
 import { prettyDesktopName } from './utils';
 
@@ -93,7 +92,6 @@ function SessionCard({ reload, session }) {
           <Buttons
             onCleaned={reload}
             onTerminated={reload}
-            onRenamed={reload}
             session={session} 
           />
         </CardFooter>
@@ -124,7 +122,7 @@ function MetadataEntry({ name, value, format, valueTitle }) {
   );
 }
 
-function Buttons({ onCleaned, onTerminated, onRenamed, session }) {
+function Buttons({ onCleaned, onTerminated, session }) {
   const toolbarStyle = {
     flexWrap: 'nowrap'
   };
@@ -139,11 +137,6 @@ function Buttons({ onCleaned, onTerminated, onRenamed, session }) {
           <i className="fa fa-bolt mr-1"></i>
           <span>Connect</span>
         </Link>
-        <RenameButton
-          className="btn-sm btn-secondary mr-2 text-nowrap"
-          onRenamed={onRenamed}
-          session={session}
-        />
         <TerminateButton
           className="btn-sm text-nowrap"
           onTerminated={onTerminated}

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -123,13 +123,9 @@ function MetadataEntry({ name, value, format, valueTitle }) {
 }
 
 function Buttons({ onCleaned, onTerminated, session }) {
-  const toolbarStyle = {
-    flexWrap: 'nowrap'
-  };
-
   if (activeStates.includes(session.state)) {
     return (
-      <div className="btn-toolbar justify-content-center" style={toolbarStyle}>
+      <div className="btn-toolbar justify-content-center">
         <Link
           className="btn btn-sm btn-primary mr-2 text-nowrap"
           to={`/sessions/${session.id}`}

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import CleanButton from './CleanSessionButton';
 import WrappedScreenshot from './Screenshot';
 import TerminateButton from './TerminateButton';
+import RenameButton from './RenameButton';
 import { CardFooter } from './CardParts';
 import { prettyDesktopName } from './utils';
 
@@ -92,6 +93,7 @@ function SessionCard({ reload, session }) {
           <Buttons
             onCleaned={reload}
             onTerminated={reload}
+            onRenamed={reload}
             session={session} 
           />
         </CardFooter>
@@ -122,7 +124,7 @@ function MetadataEntry({ name, value, format, valueTitle }) {
   );
 }
 
-function Buttons({ onCleaned, onTerminated, session }) {
+function Buttons({ onCleaned, onTerminated, onRenamed, session }) {
   if (activeStates.includes(session.state)) {
     return (
       <div className="btn-toolbar justify-content-center">
@@ -133,6 +135,11 @@ function Buttons({ onCleaned, onTerminated, session }) {
           <i className="fa fa-bolt mr-1"></i>
           <span>Connect</span>
         </Link>
+        <RenameButton
+          className="btn-sm btn-secondary mr-2"
+          onRenamed={onRenamed}
+          session={session}
+        />
         <TerminateButton
           className="btn-sm"
           onTerminated={onTerminated}

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -14,6 +14,7 @@ import {
 
 import NoVNC from './NoVNC';
 import PreparePasteButton from './PreparePasteButton';
+import RenameButton from './RenameButton';
 import TerminateButton from './TerminateButton';
 import WrappedScreenshot from './Screenshot';
 import styles from './NoVNC.module.css';
@@ -220,6 +221,14 @@ function Toolbar({
 }) {
   const { addToast } = useToast();
 
+  const renameBtn = session != null ? (
+    <RenameButton
+      className="btn-sm mr-1"
+      session={session}
+    >
+    </RenameButton>
+  ) : null;
+
   const disconnectBtn = connectionState === 'connected' ? (
     <button
       className="btn btn-secondary btn-sm mr-1"
@@ -285,6 +294,7 @@ function Toolbar({
   return (
     <div className="btn-toolbar" style={{ minHeight: '31px' }}>
       {fullscreenBtn}
+      {renameBtn}
       {disconnectBtn}
       {reconnectBtn}
       {terminateBtn}

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -230,8 +230,7 @@ function Toolbar({
       className="btn-sm btn-secondary mr-1"
       session={session}
       onRenamed={onRenamed}
-    >
-    </RenameButton>
+    />
   ) : null;
 
   const disconnectBtn = connectionState === 'connected' ? (

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -223,7 +223,7 @@ function Toolbar({
 
   const renameBtn = session != null ? (
     <RenameButton
-      className="btn-sm mr-1"
+      className="btn-sm btn-secondary mr-1"
       session={session}
     >
     </RenameButton>

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -124,6 +124,7 @@ function Connected({ id, session }) {
       onTerminate={() => setConnectionState('terminating')}
       onTerminated={() => history.push('/sessions')}
       onZenChange={() => vnc.current && vnc.current.resize()}
+      onRenamed={() => history.push(`/sessions/${session.id}`)}
       session={session}
       vnc={vnc}
     >
@@ -160,6 +161,7 @@ function Layout({
   onReconnect,
   onTerminate,
   onTerminated,
+  onRenamed,
   onZenChange,
   session,
   vnc,
@@ -189,6 +191,7 @@ function Layout({
                       connectionState={connectionState}
                       onDisconnect={onDisconnect}
                       onReconnect={onReconnect}
+                      onRenamed={onRenamed}
                       onTerminate={onTerminate}
                       onTerminated={onTerminated}
                       onZenChange={onZenChange}
@@ -211,6 +214,7 @@ function Layout({
 
 function Toolbar({
   connectionState,
+  onRenamed,
   onDisconnect,
   onReconnect,
   onTerminate,
@@ -225,6 +229,7 @@ function Toolbar({
     <RenameButton
       className="btn-sm btn-secondary mr-1"
       session={session}
+      onRenamed={onRenamed}
     >
     </RenameButton>
   ) : null;

--- a/src/api.js
+++ b/src/api.js
@@ -48,7 +48,7 @@ export function useLaunchDefaultSession() {
   return request;
 }
 
-export function useLaunchSession(desktop) {
+export function useLaunchSession(desktop, name=null) {
   const request = useFetch(
     "/sessions",
     {
@@ -59,6 +59,7 @@ export function useLaunchSession(desktop) {
       },
       body: {
         desktop: desktop.id,
+        name: name
       },
       cachePolicy: 'no-cache',
     });

--- a/src/api.js
+++ b/src/api.js
@@ -48,7 +48,7 @@ export function useLaunchDefaultSession() {
   return request;
 }
 
-export function useLaunchSession(desktop, name=null) {
+export function useLaunchSession() {
   const request = useFetch(
     "/sessions",
     {
@@ -57,13 +57,13 @@ export function useLaunchSession(desktop, name=null) {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body: {
-        desktop: desktop.id,
-        name: name
-      },
       cachePolicy: 'no-cache',
-    });
-  return request;
+    }
+  );
+  const post = function(desktop, name) {
+    return request.post({ desktop: desktop, name: name})
+  };
+  return { ...request, request, post };
 }
 
 export function useCleanSession(id) {

--- a/src/api.js
+++ b/src/api.js
@@ -82,6 +82,24 @@ export function useCleanSession(id) {
   return request;
 }
 
+export function useRenameSession(id) {
+  const request = useFetch(
+    `/sessions/${id}/rename`,
+    {
+      method: 'post',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      cachePolicy: 'no-cache',
+    }
+  );
+  const post = function(session, name) {
+    return request.post({ session: session, name: name})
+  };
+  return { ...request, request, post };
+}
+
 export function useTerminateSession(id) {
   const request = useFetch(
     `/sessions/${id}`,

--- a/src/launch-and-access-desktop-session.test.js
+++ b/src/launch-and-access-desktop-session.test.js
@@ -129,6 +129,9 @@ async function launchDesktop(desktopType, { getByText, getByRole, queryByText })
   const card = heading.closest('.card');
   const launchButton = within(card).getByRole('button', { name: 'Launch' });
   fireEvent.click(launchButton);
+  await waitFor(() => expect(queryByText('Start')).toBeInTheDocument());
+  const startButton = getByRole('button', { name: 'Start' });
+  fireEvent.click(startButton);
 }
 
 async function renderApp() {

--- a/src/launch-and-access-desktop-session.test.js
+++ b/src/launch-and-access-desktop-session.test.js
@@ -124,13 +124,13 @@ async function navigateToLaunchPage({ getAllByText, getByText, queryByText }) {
   await waitFor(() => expect(queryByText('Loading desktops...')).toBeNull());
 }
 
-async function launchDesktop(desktopType, { getByText, getByRole, queryByText }) {
+async function launchDesktop(desktopType, { getByText, getByRole, queryByText, getByTestId }) {
   const heading = getByRole('heading', { name: desktopType });
   const card = heading.closest('.card');
-  const launchButton = within(card).getByRole('button', { name: 'Launch' });
+  const launchButton = within(card).getByTestId('launch-modal-button');
   fireEvent.click(launchButton);
-  await waitFor(() => expect(queryByText('Start')).toBeInTheDocument());
-  const startButton = getByRole('button', { name: 'Start' });
+  await waitFor(() => expect(getByTestId('session-launch-button')).toBeInTheDocument());
+  const startButton = getByTestId('session-launch-button')
   fireEvent.click(startButton);
 }
 


### PR DESCRIPTION
This PR adds the ability for Flight Desktop Webapp to (optionally) give their desktop sessions a name, and the ability to rename existing sessions.

## Naming a new session

The previous functionality of a one-click `Launch` button has been replaced with a modal containing a quick explanation and input for the session name:

![Screenshot_2022-06-08_15-37-45](https://user-images.githubusercontent.com/12374447/172644402-0436c6e2-7766-4e54-91e0-6f148e6636e0.png)

## Renaming a session

A new button component has been created to accommodate renaming sessions. Clicking the `Rename` button raises a popover with an input for the new name (or a blank space, if you want to unset the name), with a pair of buttons to confirm or cancel. The button has been added to the session page and the session card component page. The name on-screen is updated automatically once the rename request has completed.

**Session card:**

![Screenshot_2022-06-08_15-39-24](https://user-images.githubusercontent.com/12374447/172645096-7d06e97e-ca15-44f4-8a25-2d09121b6ca6.png)

**Session page:**

![Screenshot_2022-06-08_15-39-38](https://user-images.githubusercontent.com/12374447/172645119-3c0e3500-0377-4eda-a118-4a244619d448.png)

**Rename popover:**


![Screenshot_2022-06-08_15-41-43](https://user-images.githubusercontent.com/12374447/172645300-1a8d85b6-889b-472b-b56d-107c83511645.png)

