### PR TITLE
Link to Flight Job overview for sessions started by Job

### DIFF
--- a/.env
+++ b/.env
@@ -28,3 +28,6 @@ REACT_APP_BRANDING_CSS_URL="/styles/branding.css"
 
 # The URL to the SSO server.
 REACT_APP_LOGIN_API_BASE_URL="/login/api/v0"
+
+# The URL to the Flight Job Webapp server
+REACT_APP_JOBS_CLIENT_BASE_URL="/job-scripts"

--- a/.env.development
+++ b/.env.development
@@ -15,18 +15,20 @@ REACT_APP_MOUNT_PATH="/dev/desktop"
 # alternate configuration below.
 #
 # NOTE:
-# * The `REACT_APP_LOGIN_API_BASE_URL` and `REACT_APP_CONFIG_FILE` can be
-#   toggled independently.
+# * The `REACT_APP_LOGIN_API_BASE_URL`, `REACT_APP_CONFIG_FILE`, and
+#   `REACT_APP_JOBS_CLIENT_BASE_URL` can be toggled independently.
 # * You need to restart this project's development server for these changes to
 #   take affect.
 #
 # Development services.
 # REACT_APP_LOGIN_API_BASE_URL="/dev/login/api/v0"
-# REACT_APP_CONFIG_FILE="/dev/desktop/config.dev.json"
+REACT_APP_CONFIG_FILE="/dev/desktop/config.dev.json"
+REACT_APP_JOBS_CLIENT_BASE_URL="/dev/job-scripts"
 
 # Production services.  That is those installed via the OS package manager.
 REACT_APP_LOGIN_API_BASE_URL="/login/api/v0"
-REACT_APP_CONFIG_FILE="/dev/desktop/config.prod-services.json"
+##REACT_APP_CONFIG_FILE="/dev/desktop/config.prod-services.json"
+#REACT_APP_JOBS_CLIENT_BASE_URL="/job-scripts"
 # ==============================================================================
 
 # ==============================================================================

--- a/src/HeaderText.js
+++ b/src/HeaderText.js
@@ -18,21 +18,35 @@ function JobLink({session, children}) {
 function HeaderText({session}) {
   const { id } = useParams();
   const sessionId = id.split('-')[0];
-  const idText = (session == null || session.name) ?
-    sessionId :
-    <JobLink session={session}>{sessionId}</JobLink>;
-  const sessionName = (session?.job_id) ?
-    <JobLink session={session}>{session?.name}</JobLink> :
-    session?.name;
-  
+
+  if (session == null) {
+    // Session hasn't been loaded yet
+    return (<span>{sessionId}</span>);
+  }
+
+  const linkedSessionName = <JobLink session={session}>{session?.name}</JobLink>;
+  const linkedId = <JobLink session={session}>{sessionId}</JobLink>;
+
   const hostname = session == null ?
     null :
     <span> running on <code className="text-reset">{session.hostname}</code></span>;
-  const title = ( session == null || session.name == null || session.name === "") ?
-    <span>{idText} {hostname}</span> :
-    <span>{sessionName} ({idText}) {hostname}</span>;
 
-  return (title)
+  if (session.name && session.job_id) {
+    // Session has name and job ID
+    return (<span>{linkedSessionName} ({sessionId}) {hostname}</span>);
+
+  } else if (session.name && !session.job_id) {
+    // Session has name but no job ID
+    return (<span>{session.name} ({sessionId}) {hostname}</span>);
+
+  } else if (!session.name && session.job_id) {
+    // Session has no name, but a job ID
+    return (<span>{linkedId} {hostname}</span>);
+
+  } else if (!session.name && !session.job_id) {
+    // Session has neither a name nor a job ID
+    return (<span>{sessionId} {hostname}</span>);
+  }
 }
 
 export default HeaderText;

--- a/src/HeaderText.js
+++ b/src/HeaderText.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+function JobLink({session, children}) {
+  const jobUrl = `${process.env.REACT_APP_JOBS_CLIENT_BASE_URL}/jobs/${session?.job_id}`;
+  return (
+    <a
+      class="text-light"
+      href={jobUrl}
+      title="Visit Flight Job overview for this session"
+    >
+      {children}
+      <i class="fa fa-external-link mx-1"/>
+    </a>
+  )
+}
+
+function HeaderText({session}) {
+  const { id } = useParams();
+  const sessionId = id.split('-')[0];
+  const idText = (session == null || session.name) ?
+    sessionId :
+    <JobLink session={session}>{sessionId}</JobLink>;
+  const sessionName = (session?.job_id) ?
+    <JobLink session={session}>{session?.name}</JobLink> :
+    session?.name;
+  
+  const hostname = session == null ?
+    null :
+    <span> running on <code className="text-reset">{session.hostname}</code></span>;
+  const title = ( session == null || session.name == null || session.name === "") ?
+    <span>{idText} {hostname}</span> :
+    <span>{sessionName} ({idText}) {hostname}</span>;
+
+  return (title)
+}
+
+export default HeaderText;

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -33,7 +33,7 @@ function SessionCard({ reload, session }) {
       name="Job ID"
       value={session.job_id}
       valueTitle="Visit Flight Job overview for this session"
-      format={id => <a href={jobUrl} target="_blank" rel="noreferrer noopener">{id}</a> }
+      format={id => <a href={jobUrl}>{id}</a> }
     /> :
     null;
 

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -27,6 +27,15 @@ function SessionCard({ reload, session }) {
   } else {
     sessionState = session.state;
   }
+  const jobUrl = `${process.env.REACT_APP_JOBS_CLIENT_BASE_URL}/jobs/${session.job_id}`;
+  const jobIdEntry = session.job_id ?
+    <MetadataEntry
+      name="Job ID"
+      value={session.job_id}
+      valueTitle="Visit Flight Job overview for this session"
+      format={id => <a href={jobUrl} target="_blank" rel="noreferrer noopener">{id}</a> }
+    /> :
+    null;
 
   return (
       <div
@@ -86,6 +95,7 @@ function SessionCard({ reload, session }) {
               value={session.last_accessed_at}
               format={timestampFormat}
             />
+            { jobIdEntry }
           </dl>
         </div>
         <CardFooter>

--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -30,9 +30,10 @@ function SessionCard({ reload, session }) {
   const jobUrl = `${process.env.REACT_APP_JOBS_CLIENT_BASE_URL}/jobs/${session.job_id}`;
   const jobIdEntry = session.job_id ?
     <MetadataEntry
-      name="Job ID"
+      name={<span><i class="fa fa-file-code-o mr-1" />Job</span>}
+      title="This session was started by Flight Job.  Click to view the related job."
       value={session.job_id}
-      valueTitle="Visit Flight Job overview for this session"
+      valueTitle="This session was started by Flight Job.  Click to view the related job."
       format={id => <a href={jobUrl}>{id}</a> }
     /> :
     null;
@@ -109,7 +110,7 @@ function SessionCard({ reload, session }) {
   );
 }
 
-function MetadataEntry({ name, value, format, valueTitle }) {
+function MetadataEntry({ name, title, value, format, valueTitle }) {
   if (value == null) {
     return null;
   }
@@ -118,7 +119,7 @@ function MetadataEntry({ name, value, format, valueTitle }) {
     <React.Fragment>
       <dt
         className="col-sm-4 text-truncate"
-        title={name}
+        title={title || name}
       >
         {name}
       </dt>

--- a/src/SessionHeaderText.js
+++ b/src/SessionHeaderText.js
@@ -7,15 +7,15 @@ function JobLink({session, children}) {
     <a
       class="text-light"
       href={jobUrl}
-      title="Visit Flight Job overview for this session"
+      title="This session was started by Flight Job.  Click to view the related job."
     >
+      <i class="fa fa-file-code-o mr-1"/>
       {children}
-      <i class="fa fa-external-link mx-1"/>
     </a>
   )
 }
 
-function HeaderText({session}) {
+function SessionHeaderText({session}) {
   const { id } = useParams();
   const sessionId = id.split('-')[0];
 
@@ -24,7 +24,7 @@ function HeaderText({session}) {
     return (<span>{sessionId}</span>);
   }
 
-  const linkedSessionName = <JobLink session={session}>{session?.name}</JobLink>;
+  const linkedSessionName = <JobLink session={session}>{session.name}</JobLink>;
   const linkedId = <JobLink session={session}>{sessionId}</JobLink>;
 
   const hostname = session == null ?
@@ -49,4 +49,4 @@ function HeaderText({session}) {
   }
 }
 
-export default HeaderText;
+export default SessionHeaderText;

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -12,7 +12,7 @@ import {
   Spinner,
 } from 'flight-webapp-components';
 
-import HeaderText from './HeaderText';
+import SessionHeaderText from './SessionHeaderText';
 import NoVNC from './NoVNC';
 import PreparePasteButton from './PreparePasteButton';
 import RenameButton from './RenameButton';
@@ -178,7 +178,7 @@ function Layout({
                 <div className="col">
                   <div className="d-flex flex-wrap align-items-center">
                     <h5 className="flex-grow-1 mb-0">
-                      <HeaderText session={session}/>
+                      <SessionHeaderText session={session}/>
                     </h5>
                     <Toolbar
                       connectionState={connectionState}

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -161,8 +161,6 @@ function JobLink({session, children}) {
       class="text-light"
       href={jobUrl}
       title="Visit Flight Job overview for this session"
-      target="_blank"
-      rel="noreferrer noopener"
     >
       {children}
       <i class="fa fa-external-link mx-1"/>

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -154,6 +154,23 @@ function Connected({ id, session }) {
   );
 }
 
+function JobLink({session, children}) {
+  const jobUrl = `${process.env.REACT_APP_JOBS_CLIENT_BASE_URL}/jobs/${session?.job_id}`;
+  return (
+    <a
+      class="text-light"
+      href={jobUrl}
+      title="Visit Flight Job overview for this session"
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      {children}
+      <i class="fa fa-external-link mx-1"/>
+    </a>
+  )
+}
+
+
 function Layout({
   children,
   connectionState,
@@ -168,12 +185,17 @@ function Layout({
 }) {
   const { id } = useParams();
   const sessionId = id.split('-')[0];
+  const idText = (session == null || session.name) ?
+    sessionId :
+    <JobLink session={session}>{sessionId}</JobLink>;
+  const sessionName = <JobLink session={session}>{session?.name}</JobLink>;
+    
   const hostname = session == null ?
     null :
     <span>running on <code className="text-reset">{session.hostname}</code></span>;
   const title = (session == null || session.name == null || session.name === "") ?
-    <span>{sessionId} {hostname}</span> :
-    <span>{session.name} ({sessionId}) {hostname}</span>;
+    <span>{idText} {hostname}</span> :
+    <span>{sessionName} ({idText}) {hostname}</span>;
 
   return (
     <div className="overflow-auto">

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -12,6 +12,7 @@ import {
   Spinner,
 } from 'flight-webapp-components';
 
+import HeaderText from './HeaderText';
 import NoVNC from './NoVNC';
 import PreparePasteButton from './PreparePasteButton';
 import RenameButton from './RenameButton';
@@ -154,21 +155,6 @@ function Connected({ id, session }) {
   );
 }
 
-function JobLink({session, children}) {
-  const jobUrl = `${process.env.REACT_APP_JOBS_CLIENT_BASE_URL}/jobs/${session?.job_id}`;
-  return (
-    <a
-      class="text-light"
-      href={jobUrl}
-      title="Visit Flight Job overview for this session"
-    >
-      {children}
-      <i class="fa fa-external-link mx-1"/>
-    </a>
-  )
-}
-
-
 function Layout({
   children,
   connectionState,
@@ -181,19 +167,6 @@ function Layout({
   session,
   vnc,
 }) {
-  const { id } = useParams();
-  const sessionId = id.split('-')[0];
-  const idText = (session == null || session.name) ?
-    sessionId :
-    <JobLink session={session}>{sessionId}</JobLink>;
-  const sessionName = <JobLink session={session}>{session?.name}</JobLink>;
-    
-  const hostname = session == null ?
-    null :
-    <span>running on <code className="text-reset">{session.hostname}</code></span>;
-  const title = (session == null || session.name == null || session.name === "") ?
-    <span>{idText} {hostname}</span> :
-    <span>{sessionName} ({idText}) {hostname}</span>;
 
   return (
     <div className="overflow-auto">
@@ -205,7 +178,7 @@ function Layout({
                 <div className="col">
                   <div className="d-flex flex-wrap align-items-center">
                     <h5 className="flex-grow-1 mb-0">
-                      {title}
+                      <HeaderText session={session}/>
                     </h5>
                     <Toolbar
                       connectionState={connectionState}


### PR DESCRIPTION
This PR adds the ability to navigate to the Flight Job Webapp overview for Desktop sessions which were started by Flight Job. When the session was not launched via Flight Job, the behaviour is as usual.

## Session card

A new row has been added to the session card metadata (see below), showing the job ID as a hyperlink to the Flight Job Webapp page.

![Screenshot_2022-06-17_16-02-57](https://user-images.githubusercontent.com/12374447/174324853-93eddcf8-8440-43e3-b3d6-e6c618d3c445.png)

## Session page

The session ID on the session page has been turned into a similarly clickable link (see below), with an icon next to it to indicate that it is a link.

![Screenshot_2022-06-17_16-03-15](https://user-images.githubusercontent.com/12374447/174324964-a729c97c-c2c8-4985-9583-0b9de287655c.png)

