### PR TITLE
Geometry UX upgrade

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import {
 } from 'flight-webapp-components';
 
 import * as Toast from './ToastContext';
+import * as UserConfig from './UserConfigContext';
 import AppLayout from './AppLayout';
 
 function App() {
@@ -24,7 +25,9 @@ function App() {
                   <Toast.Provider>
                     <Toast.Container />
                     <FetchProvider>
-                      <AppLayout />
+                      <UserConfig.Provider>
+                        <AppLayout />
+                      </UserConfig.Provider>
                     </FetchProvider>
                   </Toast.Provider>
                 </CurrentUserProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -10,8 +10,12 @@ import {
 } from 'flight-webapp-components';
 
 import * as Toast from './ToastContext';
-import * as UserConfig from './UserConfigContext';
 import AppLayout from './AppLayout';
+
+import {
+  Context as UserConfigContext,
+  Provider as UserConfigProvider
+} from './UserConfigContext';
 
 function App() {
   return (
@@ -25,9 +29,9 @@ function App() {
                   <Toast.Provider>
                     <Toast.Container />
                     <FetchProvider>
-                      <UserConfig.Provider>
+                      <UserConfigProvider>
                         <AppLayout />
-                      </UserConfig.Provider>
+                      </UserConfigProvider>
                     </FetchProvider>
                   </Toast.Provider>
                 </CurrentUserProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -11,11 +11,7 @@ import {
 
 import * as Toast from './ToastContext';
 import AppLayout from './AppLayout';
-
-import {
-  Context as UserConfigContext,
-  Provider as UserConfigProvider
-} from './UserConfigContext';
+import { Provider as UserConfigProvider } from './UserConfigContext';
 
 function App() {
   return (

--- a/src/LaunchDesktopButton.js
+++ b/src/LaunchDesktopButton.js
@@ -6,11 +6,13 @@ import classNames from 'classnames';
 
 import {
   ConfigContext,
-  utils
+  utils,
+  DefaultErrorMessage,
+  UnauthorizedError
 } from 'flight-webapp-components';
 
 import ModalContainer from "./ModalContainer";
-import { useLaunchSession } from './api';
+import { useLaunchSession, useFetchUserConfig } from './api';
 import { prettyDesktopName } from './utils';
 
 function LaunchDesktopButton({

--- a/src/RenameButton.js
+++ b/src/RenameButton.js
@@ -49,14 +49,9 @@ function RenameButton({
   const toggle= () => setShowConfirmation(!showConfirmation);
 
   const handleSubmit = e => {
+    e.preventDefault();
     renameSession();
     toggle();
-  };
-
-  const handleKeyDown = (event) => {
-    if (event.key === 'Enter') {
-      handleSubmit();
-    }
   };
 
   return (
@@ -82,40 +77,41 @@ function RenameButton({
           Rename session
         </PopoverHeader>
         <PopoverBody>
-          <p>
-            <label for="session-name">
-              Enter new name (leave blank to remove the name).
-            </label>
-            <input
-              id="session-name"
-              className="w-100"
-              name="session-name"
-              placeholder="Session name"
-              type="text"
-              ref={nameRef}
-              defaultValue={session.name}
-              onKeyDown={handleKeyDown}
-              autoFocus={true}
-            />
-          </p>
-          <ButtonToolbar className="justify-content-center">
-            <Button
-              className="mr-2"
-              onClick={toggle}
-              size="sm"
-            >
-              Cancel
-            </Button>
-            <Button
-              color="primary"
-              className="mr-2"
-              onClick={handleSubmit}
-              size="sm"
-            >
-              <i className="fa fa-pencil-square mr-1"></i>
-              Rename
-            </Button>
-          </ButtonToolbar>
+          <form onSubmit={handleSubmit}>
+            <p>
+              <label for="session-name">
+                Enter new name (leave blank to remove the name).
+              </label>
+              <input
+                id="session-name"
+                className="w-100"
+                name="session-name"
+                placeholder="Session name"
+                type="text"
+                ref={nameRef}
+                defaultValue={session.name}
+                autoFocus={true}
+              />
+            </p>
+            <ButtonToolbar className="justify-content-center">
+              <Button
+                className="mr-2"
+                onClick={toggle}
+                size="sm"
+              >
+                Cancel
+              </Button>
+              <Button
+                className="mr-2"
+                color="primary"
+                size="sm"
+                type="submit"
+              >
+                <i className="fa fa-pencil-square mr-1"></i>
+                Rename
+              </Button>
+            </ButtonToolbar>
+          </form>
         </PopoverBody>
       </Popover>
     </React.Fragment>

--- a/src/ResizeButton.js
+++ b/src/ResizeButton.js
@@ -57,12 +57,6 @@ function ResizeButton({
     toggle();
   };
 
-  const handleKeyDown = (event) => {
-    if (event.key === 'Enter') {
-      handleSubmit();
-    }
-  };
-
   return (
     <React.Fragment>
       <Button

--- a/src/ResizeButton.js
+++ b/src/ResizeButton.js
@@ -53,6 +53,7 @@ function ResizeButton({
   const toggle= () => setShowConfirmation(!showConfirmation);
 
   const handleSubmit = e => {
+    e.preventDefault();
     resizeSession();
     toggle();
   };
@@ -60,9 +61,9 @@ function ResizeButton({
   return (
     <React.Fragment>
       <Button
-      className={`${className} ${resizing ? 'disabled ' : null}` }
-      disabled={resizing}
-      id={id}
+        className={`${className} ${resizing ? 'disabled ' : null}` }
+        disabled={resizing}
+        id={id}
       >
         {
           resizing ?
@@ -80,40 +81,43 @@ function ResizeButton({
           Resize session
         </PopoverHeader>
         <PopoverBody>
-          <p>
-            <label for="session-size">
-              Enter new size:
-            </label>
-            <Input
-              id="session-geometry"
-              name="session-geometry"
-              className="w-100"
-              type="select"
-              onChange={(e) => setGeometry(e.target.value)}
-              value={geometry}
-            >
-              <GeometryOptions geometries={geometries} current={session.geometry} />
-            </Input>
-          </p>
-          <ButtonToolbar className="justify-content-center">
-            <Button
-              className="mr-2"
-              onClick={toggle}
-              size="sm"
-            >
-              Cancel
-            </Button>
-            <Button
-              color="primary"
-              className="mr-2"
-              onClick={handleSubmit}
-              size="sm"
-              disabled={geometry === session.geometry}
-            >
-              <i className="fa fa-crop mr-1"></i>
-              Resize
-            </Button>
-          </ButtonToolbar>
+          <form onSubmit={handleSubmit}>
+            <p>
+              <label for="session-size">
+                Enter new size:
+              </label>
+              <Input
+                autoFocus
+                className="w-100"
+                id="session-geometry"
+                name="session-geometry"
+                onChange={(e) => setGeometry(e.target.value)}
+                type="select"
+                value={geometry}
+              >
+                <GeometryOptions geometries={geometries} current={session.geometry} />
+              </Input>
+            </p>
+            <ButtonToolbar className="justify-content-center">
+              <Button
+                className="mr-2"
+                onClick={toggle}
+                size="sm"
+              >
+                Cancel
+              </Button>
+              <Button
+                color="primary"
+                className="mr-2"
+                size="sm"
+                type="submit"
+                disabled={geometry === session.geometry}
+              >
+                <i className="fa fa-crop mr-1"></i>
+                Resize
+              </Button>
+            </ButtonToolbar>
+          </form>
         </PopoverBody>
       </Popover>
     </React.Fragment>

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -131,7 +131,10 @@ function Connected({ id, session }) {
         session.name = newName;
         forceRender();
       }}
-      onResized={() => {}}
+      onResized={(newGeometry) => {
+        session.geometry = newGeometry;
+        forceRender();
+      }}
       session={session}
       vnc={vnc}
     >

--- a/src/UserConfigContext.js
+++ b/src/UserConfigContext.js
@@ -8,7 +8,7 @@ import {
 const Context = React.createContext({geometry: '', geometries: []});
 
 function Provider({ children }) {
-  const { get, data, loading, error } = useFetchUserConfig();
+  const { data, loading, error } = useFetchUserConfig();
 
   if (error) {
     if (utils.errorCode(data) === 'Unauthorized') {

--- a/src/UserConfigContext.js
+++ b/src/UserConfigContext.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { useFetchUserConfig } from './api';
+import {
+  DefaultErrorMessage,
+  UnauthorizedError,
+  utils
+} from 'flight-webapp-components';
+
+const initialState = null;
+const Context = React.createContext(initialState);
+
+function Provider({ children }) {
+  const { get, data, loading, error } = useFetchUserConfig();
+
+  if (error) {
+    if (utils.errorCode(error.data) === 'Unauthorized') {
+      return <UnauthorizedError />;
+    } else {
+      return <DefaultErrorMessage />;
+    }
+  } else {
+    if (loading) {
+      return null;
+    } else {
+      return (
+        <Context.Provider value={data}>
+          {children}
+        </Context.Provider>
+      )
+    }
+  }
+}
+
+export { Context, Provider }

--- a/src/UserConfigContext.js
+++ b/src/UserConfigContext.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { useFetchUserConfig } from './api';
 import {
   DefaultErrorMessage,
-  UnauthorizedError,
   utils
 } from 'flight-webapp-components';
 
@@ -14,14 +13,26 @@ function Provider({ children }) {
   const { get, data, loading, error } = useFetchUserConfig();
 
   if (error) {
-    if (utils.errorCode(error.data) === 'Unauthorized') {
-      return <UnauthorizedError />;
+    if (utils.errorCode(data) === 'Unauthorized') {
+      return (
+        <Context.Provider value={{unauthorized: "true"}}>
+          {children}
+        </Context.Provider>
+      )
     } else {
-      return <DefaultErrorMessage />;
+      return (
+        <Context.Provider value={{error: error}}>
+          {children}
+        </Context.Provider>
+      )
     }
   } else {
     if (loading) {
-      return null;
+      return (
+        <Context.Provider value={{loading: "true"}}>
+          {children}
+        </Context.Provider>
+      )
     } else {
       return (
         <Context.Provider value={data}>

--- a/src/UserConfigContext.js
+++ b/src/UserConfigContext.js
@@ -2,12 +2,10 @@ import React from 'react';
 
 import { useFetchUserConfig } from './api';
 import {
-  DefaultErrorMessage,
   utils
 } from 'flight-webapp-components';
 
-const initialState = null;
-const Context = React.createContext(initialState);
+const Context = React.createContext({geometry: '', geometries: []});
 
 function Provider({ children }) {
   const { get, data, loading, error } = useFetchUserConfig();

--- a/src/api.js
+++ b/src/api.js
@@ -23,10 +23,12 @@ export function useFetchSessions() {
 
 export function useFetchUserConfig() {
   const { currentUser } = useContext(CurrentUserContext);
+  const auth = currentUser ? [ currentUser.authToken ] : null;
+
   return useFetch(
     "/configs/user",
     { headers: { Accept: 'application/json' } },
-    [ currentUser.authToken ]);
+    auth);
 }
 
 export function useFetchSession(id) {


### PR DESCRIPTION
This PR changes the UX for setting the geometry of/resizing a session. Previously, the user had to input the desired geometry as a string, with no regard for what is and isn't allowed as a geometry string. Now, the webapp queries Flight Desktop for available options, and displays them as a dropdown menu.

- The `Launch desktop` modal queries the data at `/configs/user` with `useFetchUserConfig()`
- The resize session function uses new data that is being included in the session object (see https://github.com/openflighthpc/flight-desktop/pull/50)

Both dropdowns are rendered with default values: the launch desktop dropdown uses the default geometry set in the user configuration menu; the resize dropdown uses the current geometry.

### Launch desktop input

#### On render
![Screenshot_2022-06-23_11-50-00](https://user-images.githubusercontent.com/12374447/175282447-4a502944-1757-463c-acd7-732b25a70985.png)

#### Full dropdown

![Screenshot_2022-06-23_11-50-11](https://user-images.githubusercontent.com/12374447/175282501-99178830-c00f-431d-89bc-d113e5b4c1f4.png)

### Resize session input

#### On render

![Screenshot_2022-06-23_11-50-28](https://user-images.githubusercontent.com/12374447/175282538-5b3f10c4-7f34-4db8-997b-33049121fdba.png)

#### Full dropdown

![Screenshot_2022-06-23_11-50-39](https://user-images.githubusercontent.com/12374447/175282561-a4b1688b-e469-4e11-b0f8-2fc341e76ef9.png)

