### PR TITLE
Fixes for layout bugs

### DIFF
--- a/src/SessionCard.js
+++ b/src/SessionCard.js
@@ -44,10 +44,8 @@ function SessionCard({ reload, session }) {
         })}
         data-testid="session-card"
       >
-        <div className="row col justify-content-between mb-2 mt-3">
-          <h5
-            className="card-text text-start"
-          >
+        <div className="desktop-header">
+          <h5 className="card-text text-start">
             {title}
           </h5>
           <DropdownMenu
@@ -117,7 +115,7 @@ function DropdownMenu({ onCleaned, onTerminated, session }) {
       <a className="card-text dropdown-toggle no-caret" id="dropdownMenuButton"
          data-toggle="dropdown"
          aria-haspopup="true" aria-expanded="false">
-        <i className="fa-solid fa-ellipsis-vertical pl-2"></i>
+        <i className="fa-solid fa-ellipsis-vertical pl-3"></i>
       </a>
       <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
         <DropdownItems

--- a/src/SessionPage.js
+++ b/src/SessionPage.js
@@ -1,5 +1,5 @@
 import React, { useContext, useRef, useState } from 'react';
-import {Link, useHistory, useParams} from 'react-router-dom';
+import {useHistory, useParams} from 'react-router-dom';
 import { useToast } from './ToastContext';
 
 import {
@@ -246,6 +246,13 @@ function Toolbar({
     addToast({body, icon: 'danger', header: 'Unexpected error' });
   }
 
+  function exitToDesktops() {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+    window.location.href = '../desktop';
+  }
+
   return (
     <div className="btn-toolbar" style={{ minHeight: '31px' }}>
       <FullscreenButton onZenChange={onZenChange} />
@@ -302,14 +309,13 @@ function Toolbar({
           }
         </div>
       </div>
-      <Link
+      <div
         className="link white-text pl-4"
+        onClick={exitToDesktops}
         title="Exit to desktops"
-        to="/"
-        relative="path"
       >
         <i className="fa-solid fa-right-from-bracket"></i>
-      </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes a few issues:

- In the custom desktop workflow - Text no longer overflows desktop type cards
![image](https://github.com/openflighthpc/flight-desktop-webapp/assets/102584263/78772657-01fc-43e5-a9c8-7996a0e7a296)

- On the desktop landing page - Long desktop names no longer cause the menu dots icon to wrap onto a new line
![image](https://github.com/openflighthpc/flight-desktop-webapp/assets/102584263/32002162-b9fa-4308-aefa-9ccb24673f60)

- On a desktop session page - Fullscreen mode is exited before leaving the page (when the 'Exit to desktops' icon is clicked)
![image](https://github.com/openflighthpc/flight-desktop-webapp/assets/102584263/a3f7531f-bf6b-495a-b6e8-da4523e38523)
